### PR TITLE
Fix loggerd VAAPI linking on Linux

### DIFF
--- a/system/loggerd/SConscript
+++ b/system/loggerd/SConscript
@@ -8,6 +8,9 @@ src = ['logger.cc', 'zstd_writer.cc', 'video_writer.cc', 'encoder/encoder.cc', '
 if arch != "larch64":
   src += ['encoder/ffmpeg_encoder.cc']
   libs += ['yuv']
+  if arch != "Darwin":
+    # Vendored FFmpeg enables VA-API on desktop Linux, so link libva explicitly.
+    libs += ['va', 'va-drm', 'drm']
 
 if arch == "Darwin":
   # exclude v4l

--- a/tools/cabana/SConscript
+++ b/tools/cabana/SConscript
@@ -67,7 +67,7 @@ base_frameworks = qt_env['FRAMEWORKS']
 base_libs = [common, messaging, cereal, visionipc, 'm', 'ssl', 'crypto', 'pthread'] + qt_env["LIBS"]
 
 if arch == "Darwin":
-  base_frameworks.append('QtCharts')
+  base_frameworks += ['QtCharts', 'CoreFoundation', 'IOKit', 'Security']
 else:
   base_libs.append('Qt5Charts')
 

--- a/tools/setup_dependencies.sh
+++ b/tools/setup_dependencies.sh
@@ -58,6 +58,7 @@ function install_ubuntu_deps() {
     build-essential \
     curl \
     libcurl4-openssl-dev \
+    libva-dev \
     locales \
     git \
     xvfb

--- a/tools/setup_dependencies.sh
+++ b/tools/setup_dependencies.sh
@@ -110,7 +110,7 @@ function install_python_deps() {
   uv self update || true
 
   echo "installing python packages..."
-  uv sync --frozen --all-extras
+  retry 3 uv sync --frozen --all-extras
   source .venv/bin/activate
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

GitHub Actions run 24980278004 started failing in multiple Linux build jobs during the `Build openpilot` step, including the linked `Create UI Report` job. The shared failure was in `system/loggerd/{loggerd,encoderd}` while linking against the vendored FFmpeg static libraries:

- undefined references to `va*` symbols from VA-API
- then undefined references to DRM symbols required by `libva-drm`

This was not a UI-report-specific failure and not a simple bad test run. The underlying issue is that the current desktop Linux build links vendored FFmpeg, but does not explicitly link the additional VA-API/DRM libraries now required by those FFmpeg objects.

This PR fixes that by:

- linking desktop Linux `loggerd` binaries against `va`, `va-drm`, and `drm`
- installing `libva-dev` during Ubuntu setup so clean CI runners have the needed development symlinks available at link time
- adding a retry around `uv sync --frozen --all-extras` so transient dependency download failures do not fail setup immediately
- applying the published upstream macOS cabana fix from commaai/openpilot PR #37686 by linking `CoreFoundation`, `IOKit`, and `Security` frameworks on Darwin

I initially considered a dependency pin/revert, but local reproduction showed the Linux break is fundamentally missing link dependencies in-tree, so the source/build fix is safer and more durable than pinning FFmpeg back.

I also checked the web for similar published fixes:
- FFmpeg/libva static-link reports consistently point to missing `libva`/`libdrm` linkage or environment setup on Ubuntu runners
- commaai/openpilot issue #37685 and merged PR #37686 published the matching macOS cabana framework fix

**Verification**

- Reproduced the original Linux failure locally with `source .venv/bin/activate && scons -j$(nproc)`
- Observed linker failures on `system/loggerd/{loggerd,encoderd}` for unresolved `va*` and DRM symbols from vendored FFmpeg
- Added explicit Linux VA-API/DRM linkage plus `libva-dev` in setup
- Re-ran `source .venv/bin/activate && scons -j$(nproc)` successfully
- Inspected new PR CI failures and confirmed:
  - Linux build jobs now pass
  - one unit-tests failure was a transient `libyuv` download HTTP 502 during `uv sync`
  - macOS still had a known upstream cabana framework-link issue matching commaai/openpilot #37685 / #37686
- Updated the branch with the macOS framework fix and setup retry hardening

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd469e96-9747-4362-9f0f-3ee4e5b65336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd469e96-9747-4362-9f0f-3ee4e5b65336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

