### PR TITLE
settings_ui: fix invalid JSON by moving Honda section into YAML source

### DIFF
--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -2085,7 +2085,7 @@
               "type": "not_engaged"
             }
           ]
-        },
+        }
       ]
     },
     "hyundai": {

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
@@ -6,6 +6,17 @@ icon: vehicle
 order: 99
 kind: vehicle
 sections:
+- id: honda
+  title: Honda / Acura Settings
+  description: ''
+  items:
+  - key: HondaEnforceStockLongitudinal
+    widget: toggle
+    needs_onroad_cycle: true
+    title: 'Honda Nidec: Enforce Factory Longitudinal Control'
+    description: sunnypilot will not take over control of gas and brakes. Factory Honda Nidec longitudinal control will be used.
+    enablement:
+    - $ref: '#/macros/not_engaged'
 - id: hyundai
   title: Hyundai / Kia / Genesis Settings
   description: ''


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The [unit tests job](https://github.com/mvl-boston/openpilot/actions/runs/31284173820/job/93170114376) on `sp-honda-dev-202608` fails with 5 failures and 39 errors, almost all tracing back to one root cause: commit 60fe9d144 ("Add Honda Nidec stock longitudinal settings to vehicle configuration") hand-edited the generated `settings_ui.json` directly, leaving a trailing comma after the Honda item that makes the file invalid JSON (`JSONDecodeError: Expecting value: line 2089 column 7`).

`settings_ui.json` is a compiled artifact — the source of truth is the YAML authoring tree in `sunnypilot/sunnylink/settings_ui_src/`, and `test_committed_file_is_canonical` enforces that the committed JSON matches the compiler output.

## Fix

- Added the Honda / Acura section (the `HondaEnforceStockLongitudinal` toggle) to `settings_ui_src/pages/vehicle.yaml`, using the `not_engaged` macro the same way the equivalent Toyota toggle does.
- Regenerated `settings_ui.json` with `compile_settings_ui.py`. The output is byte-identical to the hand edit except for the removed trailing comma, so no behavior changes.

## Verification

- `compile_settings_ui.py --check` passes (committed file matches compiled output).
- All sunnylink test suites pass locally: `test_compile_settings_ui.py`, `test_settings_schema.py`, `test_settings_changes.py` — 71 passed, 1 skipped.

## Not addressed

The remaining 3 failures (`test_calibrationd.py::test_calibration_auto_reset` and two `test_locationd_scenarios.py` tests) are caused by intentional calibration/locationd threshold customizations on this fork and are deliberately left alone per the requester.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bee8662-aac7-4d94-a97e-4aa9e4da19cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bee8662-aac7-4d94-a97e-4aa9e4da19cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

