### PR TITLE
Fix UI crash in _get_version_text when git params are unset

### DIFF
--- a/selfdrive/ui/mici/layouts/home.py
+++ b/selfdrive/ui/mici/layouts/home.py
@@ -201,11 +201,14 @@ class MiciHomeLayout(Widget):
 
   def _get_version_text(self) -> tuple[str, str, str, str] | None:
     version = ui_state.params.get("Version")
-    branch = ui_state.params.get("GitBranch") + " " + ui_state.params.get("GitCommit")[:7]
+    git_branch = ui_state.params.get("GitBranch")
+    git_commit = ui_state.params.get("GitCommit")
     commit = "https://buymeacoffee.com/mvlboston"
 
-    if not all((version, branch, commit)):
+    if not all((version, git_branch, git_commit, commit)):
       return None
+
+    branch = git_branch + " " + git_commit[:7]
 
     commit_date_raw = ui_state.params.get("GitCommitDate")
     try:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

Fixes the `test_raylib_ui` failure in [CI run 31284233874](https://github.com/mvl-boston/openpilot/actions/runs/31284233874/job/93170263745?pr=142).

The UI process crashed on startup with:

```
File ".../selfdrive/ui/mici/layouts/home.py", line 204, in _get_version_text
  branch = ui_state.params.get("GitBranch") + " " + ui_state.params.get("GitCommit")[:7]
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

In environments where the `GitBranch` / `GitCommit` params are not set (such as the CI unit test runner), `params.get()` returns `None`, and the string concatenation raised a `TypeError` before the existing `if not all(...)` guard could return `None`.

The fix fetches `GitBranch` and `GitCommit` first, performs the missing-value check, and only then builds the `branch` string. Behavior with the params set is unchanged.

**Verification**

- Verified the function returns `None` when `Version`/`GitBranch`/`GitCommit` are unset (the crash scenario from CI), and returns the same tuple as before when all params are present.
- The full openpilot build isn't available in this environment, so `test_raylib_ui` itself was not re-run locally; CI on this PR will confirm.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92846066-aa74-4e0c-ad46-2a8186b48127?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92846066-aa74-4e0c-ad46-2a8186b48127&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

