### PR TITLE
Fix static analysis lint failures in scripts/plus.sh and scripts/minus.sh

### DIFF
--- a/scripts/minus.sh
+++ b/scripts/minus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PARAM="/data/params/d_tmp/CameraOffset"
 DECREMENT=0.02

--- a/scripts/plus.sh
+++ b/scripts/plus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PARAM="/data/params/d_tmp/CameraOffset"
 INCREMENT=0.02


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

Fixes the `static analysis` CI failure in [this workflow run](https://github.com/mvl-boston/openpilot/actions/runs/31285749374/job/93174117891). Two lint checks were failing on `scripts/plus.sh` and `scripts/minus.sh`:

- `check_shebang_format`: the scripts used `#!/bin/bash` instead of the required `#!/usr/bin/env bash`
- `check_shebang_scripts_are_executable`: the scripts have a shebang but were not marked executable

This PR updates the shebang in both scripts and marks them executable (mode 100644 → 100755).

**Verification**

Ran the two failing checks locally on the fixed files, and both now pass:

- `scripts/lint/check_shebang_format.sh scripts/minus.sh scripts/plus.sh`
- `python3 -m pre_commit_hooks.check_shebang_scripts_are_executable scripts/minus.sh scripts/plus.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e82a50b5-fa1c-46b4-a0c0-120f26fa3fae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e82a50b5-fa1c-46b4-a0c0-120f26fa3fae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

