### PR TITLE
Cherry-pick agnos.json fallback symlink from upstream (f8d50e0)

### DIFF
--- a/system/hardware/tici/agnos.json
+++ b/system/hardware/tici/agnos.json
@@ -1,0 +1,1 @@
+../../../openpilot/common/hardware/tici/agnos.json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

Cherry-picks upstream commaai/openpilot commit [f8d50e0](https://github.com/commaai/openpilot/commit/f8d50e062d00e1cb9bcc6ecf5a06f63ac5599eaf) ("updated: add fallback mechanism for `agnos.json` path resolution", [#38593](https://github.com/commaai/openpilot/pull/38593)) onto `sp-honda-dev-202608`, with the conflict resolved so no dangling symlinks are introduced.

**Why the cherry-pick conflicted**

The upstream commit adds two symlinks so tools that still look for `agnos.json` at its pre-restructure paths can find it:

1. `openpilot/system/hardware/tici/agnos.json` -> `../comma/agnos.json`
2. `system/hardware/tici/agnos.json` (repo root) -> `../../../openpilot/system/hardware/comma/agnos.json`

This branch **already has** symlink 1 at that exact path (created by the "mv root dirs into nested openpilot" restructure, [#38219](https://github.com/commaai/openpilot/pull/38219)), but pointing to `../../../common/hardware/tici/agnos.json` instead. Git therefore reports an **add/add conflict**: both sides added `openpilot/system/hardware/tici/agnos.json` with different contents.

The underlying divergence is that upstream has since renamed the hardware directory `tici/` -> `comma/`, so upstream's real file lives at `openpilot/common/hardware/comma/agnos.json`, while on this branch it still lives at `openpilot/common/hardware/tici/agnos.json`. Neither of the upstream symlink targets exists here — applying the commit verbatim would create two broken symlinks.

**Resolution**

- Kept our existing `openpilot/system/hardware/tici/agnos.json` -> `../../../common/hardware/tici/agnos.json` (already correct for this branch's layout).
- Retargeted the new root-level fallback symlink to this branch's real file: `system/hardware/tici/agnos.json` -> `../../../openpilot/common/hardware/tici/agnos.json`.

When this branch later picks up upstream's `tici/` -> `comma/` hardware rename, both symlinks will need to be retargeted to `comma/` along with that merge.

**Verification**

- `readlink -e` confirms both symlinks resolve to `/workspace/openpilot/common/hardware/tici/agnos.json`.
- `json.load()` on `system/hardware/tici/agnos.json` parses successfully through the symlink.
- The resulting commit only adds the root-level symlink (1 file), since the nested path was already present and unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1aac2290-e657-4daf-b77e-1c734d13e311?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aac2290-e657-4daf-b77e-1c734d13e311&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

