### PR TITLE
Rename SLC labels to SPLC in developer menus

### DIFF
--- a/selfdrive/ui/layouts/settings/developer.py
+++ b/selfdrive/ui/layouts/settings/developer.py
@@ -29,7 +29,7 @@ DESCRIPTIONS = {
     "Changing this setting will restart openpilot if the car is powered on."
   ),
   'lane_centering': tr_noop(
-    "StarPilot Lane Centering (SLC): experimentally bias the model command toward the detected lane center. " +
+    "StarPilot Lane Centering (SPLC): experimentally bias the model command toward the detected lane center. " +
     "Requires two confident lane lines and remains subject to normal curvature and jerk limits. Ported from StarPilot."
   ),
   'lane_centering_pause_on_signal': tr_noop(
@@ -109,21 +109,21 @@ class DeveloperLayout(Widget):
     self._on_enable_ui_debug(self._params.get_bool("ShowDebugInfo"))
 
     self._lane_centering_toggle = toggle_item(
-      lambda: tr("SLC (StarPilot Lane Centering)"),
+      lambda: tr("SPLC (StarPilot Lane Centering)"),
       description=lambda: tr(DESCRIPTIONS["lane_centering"]),
       initial_state=self._params.get_bool("LaneCentering"),
       callback=self._on_lane_centering,
     )
 
     self._lane_centering_pause_toggle = toggle_item(
-      lambda: tr("SLC Pause on Turn Signal"),
+      lambda: tr("SPLC Pause on Turn Signal"),
       description=lambda: tr(DESCRIPTIONS["lane_centering_pause_on_signal"]),
       initial_state=bool(self._params.get("LaneCenteringPauseOnSignal", return_default=True)),
       callback=self._on_lane_centering_pause_on_signal,
     )
 
     self._lane_center_offset_setting = multiple_button_item(
-      lambda: tr("SLC Center Offset"),
+      lambda: tr("SPLC Center Offset"),
       lambda: tr(DESCRIPTIONS["lane_center_offset"]),
       buttons=list(LANE_CENTER_OFFSET_LABELS),
       selected_index=closest_value_index(LANE_CENTER_OFFSET_VALUES, self._params.get("LaneCenterOffset", return_default=True)),
@@ -132,7 +132,7 @@ class DeveloperLayout(Widget):
     )
 
     self._lane_centering_e2e_authority_setting = multiple_button_item(
-      lambda: tr("SLC E2E Override"),
+      lambda: tr("SPLC E2E Override"),
       lambda: tr(DESCRIPTIONS["lane_centering_e2e_authority"]),
       buttons=list(LANE_CENTERING_E2E_AUTHORITY_LABELS),
       selected_index=closest_value_index(LANE_CENTERING_E2E_AUTHORITY_VALUES, self._params.get("LaneCenteringE2EAuthority", return_default=True)),

--- a/selfdrive/ui/mici/layouts/settings/developer.py
+++ b/selfdrive/ui/mici/layouts/settings/developer.py
@@ -87,16 +87,16 @@ class DeveloperLayoutMici(NavScroller):
     self._debug_mode_toggle = BigParamControl("ui debug mode", "ShowDebugInfo",
                                               toggle_callback=lambda checked: (gui_app.set_show_touches(checked),
                                                                                gui_app.set_show_fps(checked)))
-    self._lane_centering_toggle = BigParamControl("SLC (StarPilot Lane Centering)", "LaneCentering",
+    self._lane_centering_toggle = BigParamControl("SPLC (StarPilot Lane Centering)", "LaneCentering",
                                                   toggle_callback=self._update_lane_centering_settings_enabled)
-    self._lane_centering_pause_toggle = BigToggle("SLC pause on signal",
+    self._lane_centering_pause_toggle = BigToggle("SPLC pause on signal",
                                                   initial_state=bool(ui_state.params.get("LaneCenteringPauseOnSignal", return_default=True)),
                                                   toggle_callback=self._on_lane_centering_pause_on_signal)
     # explicit font sizes: at the defaults these labels wrap enough to hide the selected-value line
-    self._lane_center_offset_toggle = BigMultiToggle("SLC center offset", list(LANE_CENTER_OFFSET_LABELS),
-                                                     select_callback=self._on_lane_center_offset, font_size=42)
-    self._lane_centering_e2e_authority_toggle = BigMultiToggle("SLC e2e override", list(LANE_CENTERING_E2E_AUTHORITY_LABELS),
-                                                               select_callback=self._on_lane_centering_e2e_authority, font_size=42)
+    self._lane_center_offset_toggle = BigMultiToggle("SPLC center offset", list(LANE_CENTER_OFFSET_LABELS),
+                                                     select_callback=self._on_lane_center_offset, font_size=40)
+    self._lane_centering_e2e_authority_toggle = BigMultiToggle("SPLC e2e override", list(LANE_CENTERING_E2E_AUTHORITY_LABELS),
+                                                               select_callback=self._on_lane_centering_e2e_authority, font_size=40)
 
     self._scroller.add_widgets([
       self._adb_toggle,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

Follow-up to [PR #148](https://github.com/mvl-boston/openpilot/pull/148): sunnypilot already uses the SLC acronym (Speed Limit Control), so the StarPilot Lane Centering labels are renamed to **SPLC** in both developer menus to avoid confusion. Param names are unchanged — this is labels only.

| Menu | Before | After |
|---|---|---|
| tici/tizi | SLC (StarPilot Lane Centering) / SLC Pause on Turn Signal / SLC Center Offset / SLC E2E Override | same with SPLC |
| mici | SLC (…) lowercase variants | same with SPLC |

**Label fit**

Re-verified with the repo's real bitmap fonts under Xvfb (same method as the original PR):

- mici: the extra character pushed "SPLC center offset" past the 238px multi-toggle label width at 42px (it wrapped to three lines and hid the selected-value line), so both multi-toggles drop from 42px to 40px, where both wrap to two lines with 50px left for the value. The two plain toggles still fit at their default 42px with no toggle-pill overlap. Note "SPLC center offset" is exactly 18 characters, so without the pinned `font_size` it would also re-trigger the larger 48px short-label size.
- tici/tizi: all four titles fit at the standard 50px font — the longest ("SPLC (StarPilot Lane Centering)", 769px) sits beside a toggle, and "SPLC Center Offset" (474px) leaves 1046px for the 930px preset button row.

[mici developer menu widgets with SPLC labels, after fixes on top, broken defaults below](https://cursor.com/agents/bc-2106cfb8-011e-4476-b12a-b22171bc8591/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmici_dev_menu.png)
[tici developer menu rows with SPLC labels](https://cursor.com/agents/bc-2106cfb8-011e-4476-b12a-b22171bc8591/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftici_dev_menu.png)

**Verification**

- `ruff check` and `ty check` pass on the changed files.
- Screenshots above rendered with the real widget code and fonts under Xvfb.

The matching sunnypilot rename is in a separate PR against `sp-honda-dev-202608`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2106cfb8-011e-4476-b12a-b22171bc8591?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2106cfb8-011e-4476-b12a-b22171bc8591&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

