### PR TITLE
Rename SLC labels to SPLC in developer menus and sunnylink

### DIFF
--- a/openpilot/selfdrive/ui/mici/layouts/settings/developer.py
+++ b/openpilot/selfdrive/ui/mici/layouts/settings/developer.py
@@ -87,16 +87,16 @@ class DeveloperLayoutMici(NavScroller):
     self._debug_mode_toggle = BigParamControl("ui debug mode", "ShowDebugInfo",
                                               toggle_callback=lambda checked: (gui_app.set_show_touches(checked),
                                                                                gui_app.set_show_fps(checked)))
-    self._lane_centering_toggle = BigParamControl("SLC (StarPilot Lane Centering)", "LaneCentering",
+    self._lane_centering_toggle = BigParamControl("SPLC (StarPilot Lane Centering)", "LaneCentering",
                                                   toggle_callback=self._update_lane_centering_settings_enabled)
-    self._lane_centering_pause_toggle = BigToggle("SLC pause on signal",
+    self._lane_centering_pause_toggle = BigToggle("SPLC pause on signal",
                                                   initial_state=bool(ui_state.params.get("LaneCenteringPauseOnSignal", return_default=True)),
                                                   toggle_callback=self._on_lane_centering_pause_on_signal)
     # explicit font sizes: at the defaults these labels wrap enough to hide the selected-value line
-    self._lane_center_offset_toggle = BigMultiToggle("SLC center offset", list(LANE_CENTER_OFFSET_LABELS),
-                                                     select_callback=self._on_lane_center_offset, font_size=42)
-    self._lane_centering_e2e_authority_toggle = BigMultiToggle("SLC e2e override", list(LANE_CENTERING_E2E_AUTHORITY_LABELS),
-                                                               select_callback=self._on_lane_centering_e2e_authority, font_size=42)
+    self._lane_center_offset_toggle = BigMultiToggle("SPLC center offset", list(LANE_CENTER_OFFSET_LABELS),
+                                                     select_callback=self._on_lane_center_offset, font_size=40)
+    self._lane_centering_e2e_authority_toggle = BigMultiToggle("SPLC e2e override", list(LANE_CENTERING_E2E_AUTHORITY_LABELS),
+                                                               select_callback=self._on_lane_centering_e2e_authority, font_size=40)
 
     self._scroller.add_widgets([
       self._adb_toggle,

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/developer.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/developer.py
@@ -53,25 +53,25 @@ class DeveloperLayoutSP(DeveloperLayout):
 
     self.error_log_btn = button_item(tr("Error Log"), tr("VIEW"), tr("View the error log for sunnypilot crashes."), callback=self._on_error_log_clicked)
 
-    self.lane_centering_toggle = toggle_item_sp(tr("SLC (StarPilot Lane Centering)"),
-                                                tr("StarPilot Lane Centering (SLC): experimentally bias the model command toward the detected lane " +
+    self.lane_centering_toggle = toggle_item_sp(tr("SPLC (StarPilot Lane Centering)"),
+                                                tr("StarPilot Lane Centering (SPLC): experimentally bias the model command toward the detected lane " +
                                                    "center. Requires two confident lane lines and remains subject to normal curvature and jerk " +
                                                    "limits. Ported from StarPilot."), param="LaneCentering")
 
     # this param defaults to enabled, so it can't use the ToggleSP param binding (get_bool returns False when unset)
-    self.lane_centering_pause_toggle = toggle_item_sp(tr("SLC Pause on Turn Signal"),
+    self.lane_centering_pause_toggle = toggle_item_sp(tr("SPLC Pause on Turn Signal"),
                                                       tr("Fade the lane-centering correction out when a turn signal is active so it does not fight " +
                                                          "a lane change or turn."),
                                                       initial_state=bool(ui_state.params.get("LaneCenteringPauseOnSignal", return_default=True)),
                                                       callback=self._on_slc_pause_on_signal)
 
-    self.lane_center_offset_control = option_item_sp(tr("SLC Center Offset"), "LaneCenterOffset", -30, 30,
+    self.lane_center_offset_control = option_item_sp(tr("SPLC Center Offset"), "LaneCenterOffset", -30, 30,
                                                      tr("Shift the lane-centering target left or right of the lane center. The controller " +
                                                         "automatically reduces the offset when the detected lane is narrow."),
                                                      label_width=style.BUTTON_ACTION_WIDTH, use_float_scaling=True,
                                                      label_callback=lambda v: f"{v / 100:.2f} m")
 
-    self.lane_centering_e2e_authority_control = option_item_sp(tr("SLC E2E Override"), "LaneCenteringE2EAuthority", 0, 100,
+    self.lane_centering_e2e_authority_control = option_item_sp(tr("SPLC E2E Override"), "LaneCenteringE2EAuthority", 0, 100,
                                                                tr("How strongly a confident end-to-end model path can override lane centering when it " +
                                                                   "deliberately departs the lane center. 100% gives the model full authority; " +
                                                                   "0% disables break-in."),

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -1928,19 +1928,19 @@
         },
         {
           "id": "lane_centering",
-          "title": "StarPilot Lane Centering (SLC)",
+          "title": "StarPilot Lane Centering (SPLC)",
           "description": "Experimental confidence-gated lane centering ported from StarPilot. Biases the model command toward the detected lane center while remaining subject to normal curvature and jerk limits.",
           "items": [
             {
               "key": "LaneCentering",
               "widget": "toggle",
-              "title": "SLC (StarPilot Lane Centering)",
+              "title": "SPLC (StarPilot Lane Centering)",
               "description": "Experimentally bias the model command toward the detected lane center. Requires two confident lane lines and remains subject to normal curvature and jerk limits."
             },
             {
               "key": "LaneCenteringPauseOnSignal",
               "widget": "toggle",
-              "title": "SLC Pause on Turn Signal",
+              "title": "SPLC Pause on Turn Signal",
               "description": "Fade the lane-centering correction out when a turn signal is active so it does not fight a lane change or turn.",
               "enablement": [
                 {
@@ -1953,7 +1953,7 @@
             {
               "key": "LaneCenterOffset",
               "widget": "option",
-              "title": "SLC Center Offset",
+              "title": "SPLC Center Offset",
               "description": "Shift the lane-centering target left or right of the lane center. The controller automatically reduces the offset when the detected lane is narrow.",
               "min": -0.3,
               "max": 0.3,
@@ -1970,7 +1970,7 @@
             {
               "key": "LaneCenteringE2EAuthority",
               "widget": "option",
-              "title": "SLC E2E Override",
+              "title": "SPLC E2E Override",
               "description": "How strongly a confident end-to-end model path can override lane centering when it deliberately departs the lane center. 1.0 gives the model full authority; 0.0 disables break-in.",
               "min": 0.0,
               "max": 1.0,

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/developer.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/developer.yaml
@@ -136,18 +136,18 @@ sections:
       equals: true
     - $ref: '#/macros/advanced_only'
 - id: lane_centering
-  title: StarPilot Lane Centering (SLC)
+  title: StarPilot Lane Centering (SPLC)
   description: Experimental confidence-gated lane centering ported from StarPilot. Biases the model command toward the detected
     lane center while remaining subject to normal curvature and jerk limits.
   items:
   - key: LaneCentering
     widget: toggle
-    title: SLC (StarPilot Lane Centering)
+    title: SPLC (StarPilot Lane Centering)
     description: Experimentally bias the model command toward the detected lane center. Requires two confident lane lines
       and remains subject to normal curvature and jerk limits.
   - key: LaneCenteringPauseOnSignal
     widget: toggle
-    title: SLC Pause on Turn Signal
+    title: SPLC Pause on Turn Signal
     description: Fade the lane-centering correction out when a turn signal is active so it does not fight a lane change or
       turn.
     enablement:
@@ -156,7 +156,7 @@ sections:
       equals: true
   - key: LaneCenterOffset
     widget: option
-    title: SLC Center Offset
+    title: SPLC Center Offset
     description: Shift the lane-centering target left or right of the lane center. The controller automatically reduces the
       offset when the detected lane is narrow.
     min: -0.3
@@ -169,7 +169,7 @@ sections:
       equals: true
   - key: LaneCenteringE2EAuthority
     widget: option
-    title: SLC E2E Override
+    title: SPLC E2E Override
     description: How strongly a confident end-to-end model path can override lane centering when it deliberately departs
       the lane center. 1.0 gives the model full authority; 0.0 disables break-in.
     min: 0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

Follow-up to [PR #150](https://github.com/mvl-boston/openpilot/pull/150): sunnypilot already uses the SLC acronym (Speed Limit Control), so the StarPilot Lane Centering labels are renamed to **SPLC** everywhere they appear. Param names are unchanged — this is labels only.

Renamed surfaces:

- tici/tizi `DeveloperLayoutSP`: "SPLC (StarPilot Lane Centering)", "SPLC Pause on Turn Signal", "SPLC Center Offset", "SPLC E2E Override" (and the description text).
- mici developer menu: lowercase variants of the same labels.
- sunnylink: section title "StarPilot Lane Centering (SPLC)" and all four item titles in `settings_ui_src/pages/developer.yaml`; `settings_ui.json` regenerated (`compile_settings_ui.py --check` passes).

**Label fit**

Re-verified with the repo's real bitmap fonts under Xvfb (same method as the original PR): the extra character pushed mici's "SPLC center offset" past the 238px multi-toggle label width at 42px (it wrapped to three lines and hid the selected-value line), so both mici multi-toggles drop from 42px to 40px, where both wrap to two lines with 50px left for the value. The plain toggles still fit at their default sizes, and the tici titles fit comfortably beside the `option_item_sp` stepper controls (longest title 769px vs 830px available).

**Verification**

- `ruff check` and `ty check` pass on the changed files.
- `compile_settings_ui.py --check` and the sunnylink compile/regression tests pass (32 passed).

The matching openpilot-fork rename is [PR #151](https://github.com/mvl-boston/openpilot/pull/151) against `0111-op-honda-dev`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2106cfb8-011e-4476-b12a-b22171bc8591?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2106cfb8-011e-4476-b12a-b22171bc8591&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

