### PR TITLE
Fix CI: authenticate macOS submodule clones, skip fork-divergent locationd tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,6 +82,11 @@ jobs:
     runs-on: ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-macos-8x14' || 'macos-latest' }}
     steps:
     - uses: actions/checkout@v7
+      with:
+        # clone submodules here (authenticated with GITHUB_TOKEN) instead of in
+        # op.sh setup: anonymous clones sporadically get rate-limited on the
+        # shared macOS runners ("could not read Username for 'https://github.com'")
+        submodules: recursive
     - name: Remove Homebrew from environment
       run: |
         FILTERED=$(echo "$PATH" | tr ':' '\n' | grep -v '/opt/homebrew' | tr '\n' ':')

--- a/openpilot/selfdrive/locationd/test/test_calibrationd.py
+++ b/openpilot/selfdrive/locationd/test/test_calibrationd.py
@@ -1,6 +1,7 @@
 import random
 
 import numpy as np
+import pytest
 
 import openpilot.cereal.messaging as messaging
 from openpilot.cereal import log
@@ -84,6 +85,7 @@ class TestCalibrationd:
     np.testing.assert_allclose(c.rpy, np.zeros(3))
 
 
+  @pytest.mark.skip(reason="this fork widens MAX_ALLOWED_PITCH/YAW_SPREAD for a temporary mount, so the stock auto-reset behavior no longer applies")
   def test_calibration_auto_reset(self):
     c = Calibrator(param_put=False)
     process_messages(c, [0.0, 0.0, 0.0], BLOCK_SIZE * INPUTS_NEEDED)

--- a/openpilot/selfdrive/locationd/test/test_locationd_scenarios.py
+++ b/openpilot/selfdrive/locationd/test/test_locationd_scenarios.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from collections import defaultdict
 from enum import Enum
 
@@ -145,6 +146,7 @@ class TestLocationdScenarios:
     assert np.all(replayed_data['inputs_flag'] == orig_data['inputs_flag'])
     assert np.all(replayed_data['sensors_flag'] == orig_data['sensors_flag'])
 
+  @pytest.mark.skip(reason="this fork raises INPUT_INVALID_LIMIT for vibration tolerance, so inputsOK no longer flips after N bad measurements")
   def test_consistent_gyro_spikes(self):
     """
     Test: consistent timing spikes for N gyroscope messages in the middle of the segment
@@ -186,6 +188,7 @@ class TestLocationdScenarios:
     assert np.all(replayed_data['inputs_flag'] == orig_data['inputs_flag'])
     assert np.all(replayed_data['sensors_flag'] == orig_data['sensors_flag'])
 
+  @pytest.mark.skip(reason="this fork raises INPUT_INVALID_LIMIT for vibration tolerance, so inputsOK no longer flips after N bad measurements")
   def test_consistent_timing_spikes(self):
     """
     Test: consistent timing spikes for N accelerometer messages in the middle of the segment


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

Fixes the two failing jobs in [tests run 31428019109](https://github.com/mvl-boston/openpilot/actions/runs/31428019109) on `sp-honda-dev-202608`:

**build macOS** — `./tools/op.sh setup` failed to clone every submodule with `fatal: could not read Username for 'https://github.com'` / `fatal: expected flush after ref listing`. This is a transient GitHub-side failure (the same job passed on this branch 20 minutes earlier with no relevant change): the submodules are cloned anonymously, and anonymous git requests from the shared `macos-latest` runner IPs sporadically get rate-limited, causing git to attempt a credential prompt with no terminal available (see [actions/checkout#2351](https://github.com/actions/checkout/issues/2351)). The `op.sh` retry loop (3 attempts, ~15s) doesn't outlast the rate-limit window. Fix: pass `submodules: recursive` to `actions/checkout` in the macOS job so the clones are authenticated with `GITHUB_TOKEN` and not subject to anonymous rate limiting; `op.sh setup`'s own `git submodule update` then becomes a no-op.

**unit tests** — 3 locationd tests fail because this fork intentionally diverges from stock thresholds:
- `test_calibrationd.py::test_calibration_auto_reset` (`assert 6 == 1`): `MAX_ALLOWED_PITCH/YAW_SPREAD` were widened 10x ("widen threshold for bad mount"), so the recalibration auto-reset the test expects no longer triggers.
- `test_locationd_scenarios.py::test_consistent_gyro_spikes` / `test_consistent_timing_spikes` (`assert 0.0 == -1.0`): `INPUT_INVALID_LIMIT` was raised from 2.0 to 10.0 ("vibration tolerance"), so `inputsOK` no longer flips to False after 10 consecutive bad measurements.

Per instruction, the threshold changes are left as-is and these 3 tests are marked `@pytest.mark.skip` with reasons documenting the divergence.

**Verification**

- Edited test files compile; workflow YAML parses.
- The macOS failure was reproduced only as infra flakiness (job passed at 19:52 UTC, failed at 20:14 UTC on nearly identical code); authenticated clones remove the anonymous rate-limit failure mode.
- CI on this PR will confirm both jobs pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14345ae6-3df9-406c-8fb9-b2f1906dd776?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14345ae6-3df9-406c-8fb9-b2f1906dd776&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

