### PR TITLE
updated: make agnos.json resolution resilient across branch layouts

### DIFF
--- a/openpilot/common/hardware/tici/tests/test_agnos_updater.py
+++ b/openpilot/common/hardware/tici/tests/test_agnos_updater.py
@@ -4,9 +4,30 @@ import requests
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 MANIFEST = os.path.join(TEST_DIR, "../agnos.json")
+BASEDIR = os.path.abspath(os.path.join(TEST_DIR, "../../../../.."))
+
+# All paths where an updater (past or present) may look for agnos.json when
+# switching to this branch. Must stay in sync with AGNOS_MANIFEST_PATHS in
+# openpilot/system/updated/updated.py. Kept as symlinks to the real manifest
+# so OTA branch switches from older layouts keep working.
+COMPAT_MANIFEST_PATHS = [
+  "openpilot/system/hardware/tici/agnos.json",
+  "openpilot/system/hardware/comma/agnos.json",
+  "system/hardware/tici/agnos.json",
+  "selfdrive/hardware/tici/agnos.json",
+]
 
 
 class TestAgnosUpdater:
+
+  def test_compat_manifest_paths(self):
+    real_manifest = os.path.realpath(MANIFEST)
+    for rel_path in COMPAT_MANIFEST_PATHS:
+      path = os.path.join(BASEDIR, rel_path)
+      assert os.path.isfile(path), f"{rel_path} missing or dangling symlink"
+      assert os.path.realpath(path) == real_manifest, f"{rel_path} does not resolve to {real_manifest}"
+      with open(path) as f:
+        json.load(f)
 
   def test_manifest(self):
     with open(MANIFEST) as f:

--- a/openpilot/system/hardware/comma/agnos.json
+++ b/openpilot/system/hardware/comma/agnos.json
@@ -1,0 +1,1 @@
+../../../common/hardware/tici/agnos.json

--- a/openpilot/system/updated/updated.py
+++ b/openpilot/system/updated/updated.py
@@ -29,6 +29,25 @@ FINALIZED = os.path.join(STAGING_ROOT, "finalized")
 
 OVERLAY_INIT = Path(os.path.join(BASEDIR, ".overlay_init"))
 
+# Where agnos.json may live in the target checkout, depending on how old the
+# target branch is. Ordered from the current layout to the oldest one. The
+# current branch keeps symlinks at the legacy paths so that updaters running
+# pre-restructure code can also find the manifest when switching to it.
+AGNOS_MANIFEST_PATHS = [
+  "openpilot/system/hardware/tici/agnos.json",   # current layout
+  "openpilot/system/hardware/comma/agnos.json",  # upstream post tici -> comma rename
+  "system/hardware/tici/agnos.json",             # pre "mv root dirs into nested openpilot"
+  "selfdrive/hardware/tici/agnos.json",          # pre "rename selfdrive/hardware to system/hardware"
+]
+
+
+def get_agnos_manifest_path(basedir: str) -> str:
+  for rel_path in AGNOS_MANIFEST_PATHS:
+    manifest_path = os.path.join(basedir, rel_path)
+    if os.path.isfile(manifest_path):
+      return manifest_path
+  raise FileNotFoundError(f"no agnos.json found in {basedir}, tried: {AGNOS_MANIFEST_PATHS}")
+
 # do not allow to engage after this many hours onroad and this many routes
 HOURS_NO_CONNECTIVITY_MAX = 27
 ROUTES_NO_CONNECTIVITY_MAX = 84
@@ -209,7 +228,7 @@ def handle_agnos_update() -> None:
   cloudlog.info(f"Beginning background installation for AGNOS {updated_version}")
   set_offroad_alert("Offroad_NeosUpdate", True)
 
-  manifest_path = os.path.join(OVERLAY_MERGED, "openpilot/system/hardware/tici/agnos.json")
+  manifest_path = get_agnos_manifest_path(OVERLAY_MERGED)
   target_slot_number = get_target_slot_number()
   flash_agnos_update(manifest_path, target_slot_number, cloudlog)
   set_offroad_alert("Offroad_NeosUpdate", False)

--- a/selfdrive/hardware/tici/agnos.json
+++ b/selfdrive/hardware/tici/agnos.json
@@ -1,0 +1,1 @@
+../../../openpilot/common/hardware/tici/agnos.json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Context**

Testers reported OTA branch-switch failures into this branch, primarily `sp-honda-dev-202606` -> `sp-honda-dev-202608`. The root cause (same as [sunnypilot#1890](https://github.com/sunnypilot/sunnypilot/issues/1890), fixed upstream in [commaai/openpilot#38593](https://github.com/commaai/openpilot/pull/38593) / [f8d50e0](https://github.com/commaai/openpilot/commit/f8d50e062d00e1cb9bcc6ecf5a06f63ac5599eaf)): branch switching is done by the updater of the *currently running* branch, and `handle_agnos_update` reads `agnos.json` out of the target checkout at a hardcoded path. When AGNOS versions differ (202606 is 18.4, 202608 is 18.5, so this code path definitely runs) and the target tree doesn't have the manifest where the old updater expects it, the update fails and retries every 5 minutes.

**Status of the earlier cherry-pick (#147)**

The cherry-pick itself landed correctly: `system/hardware/tici/agnos.json` is a valid symlink on the current `sp-honda-dev-202608` tip, the manifest schema is identical to 202606's, and the old `agnos.py` can flash it. So the *specific* 202606 -> 202608 path issue was already addressed as of Aug 9 — testers who failed before that (or before the `opendbc_repo` repointing commits, which fixed a separate submodule-pin failure mode) should succeed on retry against the current tip.

However, a survey of the updater code on all 246 branches in this repo found manifest paths the current tree does **not** provide:

| Path expected by running updater | Branches | Covered before this PR |
| --- | --- | --- |
| `system/hardware/tici/agnos.json` | 228 (incl. 202606) | yes (symlink from #147) |
| `openpilot/system/hardware/tici/agnos.json` | 14 (incl. 202608) | yes |
| `openpilot/system/hardware/comma/agnos.json` | 3 (`master`, `delete5`) | **no** |
| `selfdrive/hardware/tici/agnos.json` | 1 (ancient layouts) | **no** |

Also, switching *away* from 202608 to an older-layout branch had the same bug in reverse: our updater hardcoded the one current path, which doesn't exist in old trees.

**Changes**

- Add `openpilot/system/hardware/comma/agnos.json` symlink (covers updaters built against upstream's `tici/` -> `comma/` rename, e.g. this repo's `master`).
- Add `selfdrive/hardware/tici/agnos.json` symlink (covers pre-`system/hardware` layouts and old external forks).
- `updated.py`: resolve the manifest through an ordered fallback list (`get_agnos_manifest_path`) instead of one hardcoded path, so this branch's updater can also switch to older-layout branches.
- Add a test asserting every compat path exists, resolves to the real manifest (`openpilot/common/hardware/tici/agnos.json`), and parses as JSON — so a future restructure can't silently reintroduce this failure.

**Verification**

- Fresh checkout of this branch: all four historical hardcoded paths open and parse the manifest (7 partitions).
- Fresh checkout of `sp-honda-dev-202606`: the new fallback resolver finds and parses its manifest.
- `readlink -e` confirms all symlinks resolve; both new symlinks are committed as mode `120000`.
- `ruff check` passes on the modified Python files; `py_compile` passes on `updated.py`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09c4977b-13a5-4f34-99a0-9299b821acd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09c4977b-13a5-4f34-99a0-9299b821acd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

