### PR TITLE
updated: agnos.json branch-switch resilience (backport to sp-honda-202607)

### DIFF
--- a/selfdrive/hardware/tici/agnos.json
+++ b/selfdrive/hardware/tici/agnos.json
@@ -1,0 +1,1 @@
+../../../system/hardware/tici/agnos.json

--- a/system/hardware/comma/agnos.json
+++ b/system/hardware/comma/agnos.json
@@ -1,0 +1,1 @@
+../tici/agnos.json

--- a/system/hardware/tici/tests/test_agnos_updater.py
+++ b/system/hardware/tici/tests/test_agnos_updater.py
@@ -4,9 +4,30 @@ import requests
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 MANIFEST = os.path.join(TEST_DIR, "../agnos.json")
+BASEDIR = os.path.abspath(os.path.join(TEST_DIR, "../../../.."))
+
+# All paths where an updater (past or present) may look for agnos.json when
+# switching to this branch. Must stay in sync with AGNOS_MANIFEST_PATHS in
+# system/updated/updated.py. Kept as symlinks to the real manifest so OTA
+# branch switches from other layouts keep working.
+COMPAT_MANIFEST_PATHS = [
+  "system/hardware/tici/agnos.json",
+  "openpilot/system/hardware/tici/agnos.json",
+  "openpilot/system/hardware/comma/agnos.json",
+  "selfdrive/hardware/tici/agnos.json",
+]
 
 
 class TestAgnosUpdater:
+
+  def test_compat_manifest_paths(self):
+    real_manifest = os.path.realpath(MANIFEST)
+    for rel_path in COMPAT_MANIFEST_PATHS:
+      path = os.path.join(BASEDIR, rel_path)
+      assert os.path.isfile(path), f"{rel_path} missing or dangling symlink"
+      assert os.path.realpath(path) == real_manifest, f"{rel_path} does not resolve to {real_manifest}"
+      with open(path) as f:
+        json.load(f)
 
   def test_manifest(self):
     with open(MANIFEST) as f:

--- a/system/updated/updated.py
+++ b/system/updated/updated.py
@@ -30,6 +30,25 @@ FINALIZED = os.path.join(STAGING_ROOT, "finalized")
 
 OVERLAY_INIT = Path(os.path.join(BASEDIR, ".overlay_init"))
 
+# Where agnos.json may live in the target checkout, depending on how old the
+# target branch is. Ordered from this branch's layout to other known ones.
+# This branch keeps symlinks at the other paths so that updaters running
+# other layouts can also find the manifest when switching to it.
+AGNOS_MANIFEST_PATHS = [
+  "system/hardware/tici/agnos.json",             # this branch's layout
+  "openpilot/system/hardware/tici/agnos.json",   # post "mv root dirs into nested openpilot"
+  "openpilot/system/hardware/comma/agnos.json",  # upstream post tici -> comma rename
+  "selfdrive/hardware/tici/agnos.json",          # pre "rename selfdrive/hardware to system/hardware"
+]
+
+
+def get_agnos_manifest_path(basedir: str) -> str:
+  for rel_path in AGNOS_MANIFEST_PATHS:
+    manifest_path = os.path.join(basedir, rel_path)
+    if os.path.isfile(manifest_path):
+      return manifest_path
+  raise FileNotFoundError(f"no agnos.json found in {basedir}, tried: {AGNOS_MANIFEST_PATHS}")
+
 # do not allow to engage after this many hours onroad and this many routes
 HOURS_NO_CONNECTIVITY_MAX = 27
 ROUTES_NO_CONNECTIVITY_MAX = 84
@@ -210,7 +229,7 @@ def handle_agnos_update() -> None:
   cloudlog.info(f"Beginning background installation for AGNOS {updated_version}")
   set_offroad_alert("Offroad_NeosUpdate", True)
 
-  manifest_path = os.path.join(OVERLAY_MERGED, "system/hardware/tici/agnos.json")
+  manifest_path = get_agnos_manifest_path(OVERLAY_MERGED)
   target_slot_number = get_target_slot_number()
   flash_agnos_update(manifest_path, target_slot_number, cloudlog)
   set_offroad_alert("Offroad_NeosUpdate", False)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Investigation of the sp-honda-202605 -> sp-honda-202607 complaint**

The reported failure on that pair is **not** the agnos.json path bug that [PR #154](https://github.com/mvl-boston/openpilot/pull/154) fixes on `sp-honda-dev-202608`. Everything checkable from the repo side is healthy for that switch:

- `sp-honda-202607` has the real manifest at `system/hardware/tici/agnos.json` — exactly where 202605's updater hardcodes it (its `updated.py` is functionally identical; only non-functional `params.put` differences).
- `agnos.py` (the flasher) is byte-identical between 202605 and 202607, and AGNOS 18.4 does differ from 202605's 17.2, so the flash path runs — all seven partition image URLs in 202607's manifest return HTTP 200.
- All of 202607's pinned submodule commits are anonymously fetchable.
- All 9 LFS pointers that changed between 202605 and 202607 exist on the sunnypilot GitLab LFS store.

So that complaint has a different, likely device-specific or transient cause. To diagnose it, we'd need the device's `LastUpdateException` param (shown in Settings -> Software when updates fail) or `/data/log` output from the failing device.

**What this PR does**

Even though the 202605 pair doesn't need it, `sp-honda-202607` still lacks resistance for other switch pairs: updaters built against upstream's `tici/` -> `comma/` rename (this repo's `master`, `delete5`) and ancient `selfdrive/hardware` layouts cannot find the manifest in this tree, and this branch's own updater hardcodes a single path so it cannot switch to branches with other layouts. This backports PR #154, adapted to this branch's layout (real manifest at `system/hardware/tici/agnos.json`, `openpilot/` is a directory of self-symlinks):

- Add `system/hardware/comma/agnos.json -> ../tici/agnos.json`; `openpilot/system/hardware/comma/agnos.json` then resolves through the existing `openpilot/system -> ../system/` self-symlink.
- Add `selfdrive/hardware/tici/agnos.json` symlink for pre-`system/hardware` layouts.
- `updated.py`: resolve the manifest via an ordered fallback list (`get_agnos_manifest_path`) instead of one hardcoded path.
- Add a test asserting every compat path exists, resolves to the real manifest, and parses as JSON.

**Verification**

- Fresh checkout of this branch: all four historical updater paths open and parse the manifest (7 partitions).
- `ruff check` passes on the modified files; `py_compile` passes on `updated.py`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09c4977b-13a5-4f34-99a0-9299b821acd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09c4977b-13a5-4f34-99a0-9299b821acd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

