### PR TITLE
setup: only show low voltage warning when a car harness is detected

### DIFF
--- a/openpilot/system/ui/tici_setup.py
+++ b/openpilot/system/ui/tici_setup.py
@@ -125,13 +125,31 @@ class Setup(Widget):
 
     self._downloading_body_label = Label("Downloading...", TITLE_FONT_SIZE, FontWeight.MEDIUM, text_padding=20)
 
+    if self._low_voltage() and self._car_detected():
+      self.state = SetupState.LOW_VOLTAGE
+
+  @staticmethod
+  def _low_voltage() -> bool:
     try:
       with open("/sys/class/hwmon/hwmon1/in1_input") as f:
-        voltage = float(f.read().strip()) / 1000.0
-        if voltage < 7:
-          self.state = SetupState.LOW_VOLTAGE
+        return (float(f.read().strip()) / 1000.0) < 7
     except (FileNotFoundError, ValueError):
-      self.state = SetupState.LOW_VOLTAGE
+      return True
+
+  @staticmethod
+  def _car_detected() -> bool:
+    # Low voltage is only a problem when wired into a car, where it indicates a bad
+    # harness connection or a blown fuse. When powered from a wall charger or a
+    # computer (e.g. running setup at home), low voltage is expected and harmless,
+    # so don't warn. The harness is detected through the SBU lines, which works
+    # even if the car isn't supplying 12V.
+    try:
+      from panda import Panda
+      with Panda(cli=False, disable_checks=False) as p:
+        return p.health()['car_harness_status'] != Panda.HARNESS_STATUS_NC
+    except Exception:
+      # can't talk to the panda, so there's no evidence we're in a car
+      return False
 
   def _render(self, rect: rl.Rectangle):
     if self.state == SetupState.LOW_VOLTAGE:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

The "WARNING: Low Voltage" screen in the setup app was introduced in Sept 2021 by [commaai#22342](https://github.com/commaai/openpilot/pull/22342) (`setup: add low voltage warning`), and was carried over unchanged into the raylib rewrite ([commaai#35140](https://github.com/commaai/openpilot/pull/35140)). It triggers whenever the input voltage is below 7V, which is true for every ordinary wall charger and computer USB port — not just for a faulty car installation, which is the case it was meant to catch.

## Change

Only show the warning when the device is actually wired into a car. Car detection uses the panda's SBU-line harness detection (`car_harness_status` from the health packet), which works even when the car isn't supplying 12V — so the genuinely useful case (in a car, harness detected, but no 12V, e.g. a blown fuse or bad OBD-C connection) still shows the warning.

If the panda can't be reached, we assume we're not in a car and skip the warning, since a bench/home power-up is the overwhelmingly likely reason for low voltage.

## Notes

This does not address the separate issue where the device halts entirely (black screen, panda blue LED blinking) on weak power sources. That halt comes from AGNOS's `power_drop_monitor.py` (in `commaai/agnos-builder`), which force-halts the SOM whenever the 5V bus sags below 4V for more than 100 ms, and the panda firmware then keeps the SOM in standby until power is re-plugged or a harness/ignition edge occurs. That must be fixed in agnos-builder.

## Testing

- `python3 -m py_compile` and `ruff check` pass.
- Not yet tested on device (needs a tici in setup mode, in and out of a car).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75fb9ef7-1157-4d96-927b-6ca0f171ca76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75fb9ef7-1157-4d96-927b-6ca0f171ca76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

