### PR TITLE
Only run AGNOS power drop monitor when in a car

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -12,6 +12,12 @@ function agnos_init {
   # set success flag for current boot slot
   sudo abctl --set_success
 
+  # The AGNOS power drop monitor halts the SOM when the input voltage sags
+  # below 4V, which weak USB power sources (wall chargers, computer ports)
+  # commonly do under boot load. Stop it here to cover the high power draw
+  # startup phase; hardwared starts it back up once a car harness is detected.
+  sudo systemctl stop power_drop_monitor 2> /dev/null || true
+
   # TODO: do this without udev in AGNOS
   # udev does this, but sometimes we startup faster
   sudo chgrp gpu /dev/adsprpc-smd /dev/ion /dev/kgsl-3d0

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -221,6 +221,7 @@ def hardware_thread(end_event, hw_queue) -> None:
   offroad_temp_filter = FirstOrderFilter(0., TEMP_TAU, DT_HW, initialized=False)
   should_start_prev = False
   in_car = False
+  in_car_prev: bool | None = None
   engaged_prev = False
   pwrsave = False
   offroad_cycle_count = 0
@@ -263,6 +264,16 @@ def hardware_thread(end_event, hw_queue) -> None:
       if onroad_conditions["ignition"]:
         onroad_conditions["ignition"] = False
         cloudlog.error("panda timed out onroad")
+
+    # AGNOS's power drop monitor does a controlled halt when the input voltage
+    # sags below 4V, so an abrupt car power cut doesn't corrupt data. On a wall
+    # charger or computer USB port those sags are normal and the halt leaves the
+    # device looking dead, so only run the monitor when wired into a car.
+    if HARDWARE.get_device_type() in ("tici", "tizi") and in_car != in_car_prev:
+      action = "start" if in_car else "stop"
+      cloudlog.warning(f"power_drop_monitor: {action} (in_car={in_car})")
+      subprocess.run(["sudo", "systemctl", action, "power_drop_monitor"], check=False)
+      in_car_prev = in_car
 
     # Run at 2Hz, plus either edge of ignition
     ign_edge = (started_ts is not None) != all(onroad_conditions.values())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

AGNOS ships a `power_drop_monitor` systemd service ([source](https://github.com/commaai/agnos-builder/blob/master/userspace/root/usr/comma/power_drop_monitor.py)) that arms the INA231 power monitor to alert when the input bus voltage drops below 4V. On alert, if the voltage is still low 100 ms later, it force-halts the SOM (`halt -f`). The intent is a clean shutdown when car power is abruptly cut, protecting against data corruption.

On weak USB power sources (old wall chargers, computer USB-A ports), sags below 4V are normal under boot load. The monitor then halts the device mid-boot, producing the "dead device" symptom: black screen with the panda's blue power-save LED blinking. The panda firmware keeps the SOM in standby after that, so nothing recovers it short of physically re-plugging power or connecting to a car (harness insertion / ignition edge).

## Change

Run the monitor only when the device is in a car:

- `launch_chffrplus.sh`: stop `power_drop_monitor` at openpilot launch, covering the high-power-draw startup phase (manager build/start, camera init).
- `hardwared`: start the service when the panda's harness detection reports a car connection, stop it when disconnected. Applies to tici/tizi only, matching the service's own `ExecCondition`.

In-car behavior is preserved: once the harness is detected, the monitor runs exactly as before.

## Limitations

- The service arms at `multi-user.target` and openpilot only stops it once the `comma` service launches, so there is a window of a few seconds early in boot where a very weak source can still trigger the halt. Fully closing that window requires changing agnos-builder itself (gate the monitor on car-level input voltage).
- A related openpilot-side fix for the setup app's "WARNING: Low Voltage" screen is in #158.

## Testing

- `py_compile`, `bash -n`, and `ruff check` pass.
- Not yet tested on device. To verify: power the device from a weak charger — it should boot fully; then check `systemctl status power_drop_monitor` shows inactive at home and active after plugging into the car.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75fb9ef7-1157-4d96-927b-6ca0f171ca76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75fb9ef7-1157-4d96-927b-6ca0f171ca76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

