### PR TITLE
Highlight the download update button when a download is ready

### DIFF
--- a/selfdrive/ui/mici/layouts/settings/device.py
+++ b/selfdrive/ui/mici/layouts/settings/device.py
@@ -8,7 +8,7 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.common.time_helpers import system_time_valid
 from openpilot.system.ui.widgets.scroller import NavRawScrollPanel, NavScroller
-from openpilot.selfdrive.ui.mici.widgets.button import BigButton, BigCircleButton
+from openpilot.selfdrive.ui.mici.widgets.button import BigButton, BigCircleButton, COMPLICATION_GREY, LABEL_COLOR
 from openpilot.selfdrive.ui.mici.widgets.dialog import BigDialog, BigConfirmationDialog, BigInputDialog
 from openpilot.selfdrive.ui.mici.widgets.pairing_dialog import PairingDialog
 from openpilot.selfdrive.ui.mici.onroad.driver_camera_dialog import DriverCameraDialog
@@ -165,6 +165,7 @@ class PairBigButton(BigButton):
 
 
 UPDATER_TIMEOUT = 10.0  # seconds to wait for updater to respond
+DOWNLOAD_READY_GREEN = rl.Color(46, 204, 113, 255)
 
 
 class UpdateOpenpilotBigButton(BigButton):
@@ -177,6 +178,7 @@ class UpdateOpenpilotBigButton(BigButton):
     self._waiting_for_updater_t: float | None = None
     self._hide_value_t: float | None = None
     self._state: UpdaterState = UpdaterState.IDLE
+    self._download_ready = False
 
     ui_state.add_offroad_transition_callback(self.offroad_transition)
 
@@ -213,11 +215,27 @@ class UpdateOpenpilotBigButton(BigButton):
     else:
       self.set_text("update openpilot")
 
+  def _set_download_ready(self, ready: bool):
+    # Make the "download update" state stand out so users know it's the next step
+    if ready == self._download_ready:
+      return
+    self._download_ready = ready
+    self.set_icon_color(DOWNLOAD_READY_GREEN if ready else None)
+    self._sub_label.set_text_color(LABEL_COLOR if ready else COMPLICATION_GREY)
+
+  def _handle_background(self) -> tuple[rl.Texture, float, float, float]:
+    txt_bg, btn_x, btn_y, scale = super()._handle_background()
+    # brighten the button while a download is ready
+    if self._download_ready and self.enabled and not self.is_pressed:
+      txt_bg = self._txt_pressed_bg
+    return txt_bg, btn_x, btn_y, scale
+
   def _update_state(self):
     super()._update_state()
 
     if ui_state.started:
       self.set_enabled(False)
+      self._set_download_ready(False)
       return
 
     updater_state = ui_state.params.get("UpdaterState") or ""
@@ -280,6 +298,8 @@ class UpdateOpenpilotBigButton(BigButton):
       else:
         if self.get_value() != "":
           self.set_value("")
+
+    self._set_download_ready(self._state == UpdaterState.IDLE and self.get_value() == "download update" and self.enabled)
 
     if self._state != UpdaterState.WAITING_FOR_UPDATER:
       self._waiting_for_updater_t = None

--- a/selfdrive/ui/mici/layouts/settings/device.py
+++ b/selfdrive/ui/mici/layouts/settings/device.py
@@ -165,7 +165,8 @@ class PairBigButton(BigButton):
 
 
 UPDATER_TIMEOUT = 10.0  # seconds to wait for updater to respond
-DOWNLOAD_READY_GREEN = rl.Color(46, 204, 113, 255)
+# same green as the keyboard enter pill (icons_mici/settings/keyboard/enter.png)
+DOWNLOAD_READY_GREEN = rl.Color(16, 104, 38, 207)
 
 
 class UpdateOpenpilotBigButton(BigButton):
@@ -220,7 +221,6 @@ class UpdateOpenpilotBigButton(BigButton):
     if ready == self._download_ready:
       return
     self._download_ready = ready
-    self.set_icon_color(DOWNLOAD_READY_GREEN if ready else None)
     self._sub_label.set_text_color(LABEL_COLOR if ready else COMPLICATION_GREY)
 
   def _handle_background(self) -> tuple[rl.Texture, float, float, float]:
@@ -229,6 +229,14 @@ class UpdateOpenpilotBigButton(BigButton):
     if self._download_ready and self.enabled and not self.is_pressed:
       txt_bg = self._txt_pressed_bg
     return txt_bg, btn_x, btn_y, scale
+
+  def _draw_content(self, btn_y: float):
+    if self._download_ready and self._txt_icon:
+      # white icon on a green disc, echoing the keyboard enter arrow that led here
+      x = self._rect.x + self._rect.width - 30 - self._txt_icon.width / 2
+      y = btn_y + 30 + self._txt_icon.height / 2
+      rl.draw_circle(int(x), int(y), 50, DOWNLOAD_READY_GREEN)
+    super()._draw_content(btn_y)
 
   def _update_state(self):
     super()._update_state()

--- a/selfdrive/ui/mici/widgets/button.py
+++ b/selfdrive/ui/mici/widgets/button.py
@@ -18,6 +18,7 @@ SCROLLING_SPEED_PX_S = 50
 COMPLICATION_SIZE    = 36
 LABEL_COLOR          = rl.Color(255, 255, 255, int(255 * 0.9))
 COMPLICATION_GREY    = rl.Color(0xAA, 0xAA, 0xAA, 255)
+ICON_COLOR           = rl.Color(255, 255, 255, int(255 * 0.9))
 PRESSED_SCALE = 1.15 if DO_ZOOM else 1.07
 
 
@@ -113,6 +114,7 @@ class BigButton(Widget):
     self.text = text
     self.value = value
     self._txt_icon = icon
+    self._icon_color = ICON_COLOR
     self._scroll = scroll
 
     self._scale_filter = BounceFilter(1.0, 0.1, 1 / gui_app.target_fps)
@@ -133,6 +135,9 @@ class BigButton(Widget):
 
   def set_icon(self, icon: Union[rl.Texture, None]):
     self._txt_icon = icon
+
+  def set_icon_color(self, color: Union[rl.Color, None]):
+    self._icon_color = color if color is not None else ICON_COLOR
 
   def set_rotate_icon(self, rotate: bool):
     if rotate and self._rotate_icon_t is not None:
@@ -248,7 +253,7 @@ class BigButton(Widget):
       source_rec = rl.Rectangle(0, 0, self._txt_icon.width, self._txt_icon.height)
       dest_rec = rl.Rectangle(x, y, self._txt_icon.width, self._txt_icon.height)
       origin = rl.Vector2(self._txt_icon.width / 2, self._txt_icon.height / 2)
-      rl.draw_texture_pro(self._txt_icon, source_rec, dest_rec, origin, rotation, rl.Color(255, 255, 255, int(255 * 0.9)))
+      rl.draw_texture_pro(self._txt_icon, source_rec, dest_rec, origin, rotation, self._icon_color)
 
   def _render(self, _):
     txt_bg, btn_x, btn_y, scale = self._handle_background()

--- a/selfdrive/ui/mici/widgets/button.py
+++ b/selfdrive/ui/mici/widgets/button.py
@@ -18,7 +18,6 @@ SCROLLING_SPEED_PX_S = 50
 COMPLICATION_SIZE    = 36
 LABEL_COLOR          = rl.Color(255, 255, 255, int(255 * 0.9))
 COMPLICATION_GREY    = rl.Color(0xAA, 0xAA, 0xAA, 255)
-ICON_COLOR           = rl.Color(255, 255, 255, int(255 * 0.9))
 PRESSED_SCALE = 1.15 if DO_ZOOM else 1.07
 
 
@@ -114,7 +113,6 @@ class BigButton(Widget):
     self.text = text
     self.value = value
     self._txt_icon = icon
-    self._icon_color = ICON_COLOR
     self._scroll = scroll
 
     self._scale_filter = BounceFilter(1.0, 0.1, 1 / gui_app.target_fps)
@@ -135,9 +133,6 @@ class BigButton(Widget):
 
   def set_icon(self, icon: Union[rl.Texture, None]):
     self._txt_icon = icon
-
-  def set_icon_color(self, color: Union[rl.Color, None]):
-    self._icon_color = color if color is not None else ICON_COLOR
 
   def set_rotate_icon(self, rotate: bool):
     if rotate and self._rotate_icon_t is not None:
@@ -253,7 +248,7 @@ class BigButton(Widget):
       source_rec = rl.Rectangle(0, 0, self._txt_icon.width, self._txt_icon.height)
       dest_rec = rl.Rectangle(x, y, self._txt_icon.width, self._txt_icon.height)
       origin = rl.Vector2(self._txt_icon.width / 2, self._txt_icon.height / 2)
-      rl.draw_texture_pro(self._txt_icon, source_rec, dest_rec, origin, rotation, self._icon_color)
+      rl.draw_texture_pro(self._txt_icon, source_rec, dest_rec, origin, rotation, rl.Color(255, 255, 255, int(255 * 0.9)))
 
   def _render(self, _):
     txt_bg, btn_x, btn_y, scale = self._handle_background()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

After switching branches, the UI autoswipes to the update button, but the button looks dim in its "download update" state, so users don't realize that pressing download is the next step.

This PR makes the update button stand out whenever a download is ready (`download update` shown), which includes the moment right after the branch-switch autoswipe:

- The button uses the bright "pressed" background instead of the dim default one.
- The circular-arrows update icon is drawn as a white glyph on a green disc, using the exact same green as the keyboard enter arrow pill (`icons_mici/settings/keyboard/enter.png`, rgb(16, 104, 38) at ~81% alpha). This visually links the two "next step" cues: the green enter arrow that confirms the branch name, then the green download circle that appears after the autoswipe.
- The "download update" text is brightened from grey to the standard white label color.

The highlight clears automatically once the button is pressed or leaves the download-ready state (downloading, up to date, reboot prompt, onroad, etc.).

Changes:
- `selfdrive/ui/mici/layouts/settings/device.py`: `UpdateOpenpilotBigButton` now tracks a download-ready state that brightens the background and text and draws the green disc behind the icon.

**Verification**

Rendered the button headlessly (raylib under Xvfb). Top is the current dim appearance, bottom is the new download-ready appearance, with the actual keyboard enter arrow pill rendered at the right for color comparison (blocky font is just a test-environment fallback; device uses the real Inter font atlases):

[Before (dim) vs after (bright with green disc), enter arrow pill at right for color comparison](https://cursor.com/agents/bc-12892cce-82dc-4725-b442-cd32cd14888c/artifacts?path=%2Ftmp%2Fdownload_button_before_after.png)

Also ran `ruff check` on the modified file (passes) and byte-compiled it.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12892cce-82dc-4725-b442-cd32cd14888c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12892cce-82dc-4725-b442-cd32cd14888c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

