### PR TITLE
updated: make agnos.json resolution resilient across branch layouts

### DIFF
--- a/openpilot/common/hardware/comma/tests/test_agnos_updater.py
+++ b/openpilot/common/hardware/comma/tests/test_agnos_updater.py
@@ -4,10 +4,31 @@ import requests
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 MANIFEST = os.path.join(TEST_DIR, "../agnos.json")
+BASEDIR = os.path.abspath(os.path.join(TEST_DIR, "../../../../.."))
+
+# All paths where an updater (past or present) may look for agnos.json when
+# switching to this branch. Must stay in sync with AGNOS_MANIFEST_PATHS in
+# openpilot/system/updated/updated.py. Kept as symlinks to the real manifest
+# so OTA branch switches from older layouts keep working.
+COMPAT_MANIFEST_PATHS = [
+  "openpilot/system/hardware/comma/agnos.json",
+  "openpilot/system/hardware/tici/agnos.json",
+  "system/hardware/tici/agnos.json",
+  "selfdrive/hardware/tici/agnos.json",
+]
 
 
 from openpilot.common.test import OpenpilotTestCase
 class TestAgnosUpdater(OpenpilotTestCase):
+
+  def test_compat_manifest_paths(self):
+    real_manifest = os.path.realpath(MANIFEST)
+    for rel_path in COMPAT_MANIFEST_PATHS:
+      path = os.path.join(BASEDIR, rel_path)
+      assert os.path.isfile(path), f"{rel_path} missing or dangling symlink"
+      assert os.path.realpath(path) == real_manifest, f"{rel_path} does not resolve to {real_manifest}"
+      with open(path) as f:
+        json.load(f)
 
   def test_manifest(self):
     with open(MANIFEST) as f:

--- a/openpilot/system/updated/updated.py
+++ b/openpilot/system/updated/updated.py
@@ -29,6 +29,27 @@ FINALIZED = os.path.join(STAGING_ROOT, "finalized")
 
 OVERLAY_INIT = Path(os.path.join(BASEDIR, ".overlay_init"))
 
+# Where agnos.json may live in the target checkout, depending on how old the
+# target branch is. Ordered from the current layout to the oldest one. The
+# current branch keeps symlinks at the legacy paths so that updaters running
+# pre-restructure code can also find the manifest when switching to it.
+AGNOS_MANIFEST_PATHS = [
+  "openpilot/system/hardware/comma/agnos.json",   # current layout
+  "openpilot/common/hardware/comma/agnos.json",   # direct common path
+  "openpilot/system/hardware/tici/agnos.json",    # upstream tici symlink layout
+  "system/hardware/tici/agnos.json",              # pre "mv root dirs into nested openpilot"
+  "selfdrive/hardware/tici/agnos.json",           # pre "rename selfdrive/hardware to system/hardware"
+  "openpilot/common/hardware/tici/agnos.json",    # pre tici -> comma rename
+]
+
+
+def get_agnos_manifest_path(basedir: str) -> str:
+  for rel_path in AGNOS_MANIFEST_PATHS:
+    manifest_path = os.path.join(basedir, rel_path)
+    if os.path.isfile(manifest_path):
+      return manifest_path
+  raise FileNotFoundError(f"no agnos.json found in {basedir}, tried: {AGNOS_MANIFEST_PATHS}")
+
 # do not allow to engage after this many hours onroad and this many routes
 HOURS_NO_CONNECTIVITY_MAX = 27
 ROUTES_NO_CONNECTIVITY_MAX = 84
@@ -208,7 +229,7 @@ def handle_agnos_update() -> None:
 
   cloudlog.info(f"Beginning background installation for AGNOS {updated_version}")
 
-  manifest_path = os.path.join(OVERLAY_MERGED, "openpilot/system/hardware/comma/agnos.json")
+  manifest_path = get_agnos_manifest_path(OVERLAY_MERGED)
   target_slot_number = get_target_slot_number()
   flash_agnos_update(manifest_path, target_slot_number, cloudlog)
 

--- a/selfdrive/hardware/tici/agnos.json
+++ b/selfdrive/hardware/tici/agnos.json
@@ -1,0 +1,1 @@
+../../../openpilot/common/hardware/comma/agnos.json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Context**

Branch switching is done by the updater of the *currently running* branch, and `handle_agnos_update` reads `agnos.json` out of the target checkout at a hardcoded path. When AGNOS versions differ and the target tree doesn't have the manifest where the old updater expects it, the update fails and retries every 5 minutes.

This is the same root cause fixed in [PR #154](https://github.com/mvl-boston/openpilot/pull/154) on `sp-honda-dev-202608`. A direct cherry-pick of that PR did not apply cleanly because `delete5` uses a different layout: the real manifest lives at `openpilot/common/hardware/comma/agnos.json` (not `openpilot/common/hardware/tici/agnos.json`), and several compat symlinks from upstream #38593 were already present.

**What this PR does**

Adapted from PR #154 for `delete5`'s layout:

- Add `selfdrive/hardware/tici/agnos.json` symlink for pre-`system/hardware` layouts (the one missing compat path).
- `updated.py`: resolve the manifest via an ordered fallback list (`get_agnos_manifest_path`) instead of one hardcoded path, so this branch's updater can switch to branches with other layouts.
- Add a test asserting every compat path exists, resolves to the real manifest, and parses as JSON — so a future restructure can't silently reintroduce this failure.

Existing symlinks already on `delete5` that cover incoming updaters from other layouts:

| Path | Status |
| --- | --- |
| `openpilot/system/hardware/comma/agnos.json` | already present |
| `openpilot/system/hardware/tici/agnos.json` | already present (from #38593) |
| `system/hardware/tici/agnos.json` | already present (from #38593) |
| `selfdrive/hardware/tici/agnos.json` | **added by this PR** |

**Verification**

- All four compat symlink paths resolve to `openpilot/common/hardware/comma/agnos.json` and parse as JSON (7 partitions).
- `get_agnos_manifest_path` finds the manifest on a fresh checkout of this branch.
- `py_compile` passes on `updated.py`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0c7bf2f-97f3-4eae-a773-660a94b29573?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0c7bf2f-97f3-4eae-a773-660a94b29573&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

