### PR TITLE
Fix AGNOS updater serial import without LFS access

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -21,6 +21,8 @@ function agnos_init {
   if [ $(< /VERSION) != "$AGNOS_VERSION" ]; then
     AGNOS_PY="$DIR/openpilot/common/hardware/comma/agnos.py"
     MANIFEST="$DIR/openpilot/system/hardware/comma/agnos.json"
+    # Stale updater zipapp still imports pyserial; repo root serial/ shim is on PYTHONPATH.
+    export PYTHONPATH="$DIR${PYTHONPATH:+:$PYTHONPATH}"
     if $AGNOS_PY --verify $MANIFEST; then
       sudo reboot
     fi

--- a/openpilot/common/hardware/comma/tests/test_serial_shim.py
+++ b/openpilot/common/hardware/comma/tests/test_serial_shim.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import patch
+
+
+class TestSerialShim(unittest.TestCase):
+  def test_serial_shim_exports(self):
+    # Simulate device boot: repo root on PYTHONPATH, no pyserial installed.
+    with patch.dict(sys.modules, {"serial": None}):
+      sys.modules.pop("serial", None)
+      serial = importlib.import_module("serial")
+      from openpilot.common.serial import Serial, SerialException
+
+      self.assertIs(serial.Serial, Serial)
+      self.assertIs(serial.SerialException, SerialException)
+      self.assertIs(serial.VTIMESerial, Serial)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -1,0 +1,12 @@
+"""Pyserial compatibility shim for the prebuilt AGNOS updater zipapp.
+
+Upstream removed pyserial (#38311) in favor of openpilot.common.serial, but the
+updater LFS blob was never rebuilt and still does `import serial`. Putting this
+package on PYTHONPATH lets that stale binary keep working without LFS access.
+"""
+from openpilot.common.serial import Serial, SerialException
+
+# Old updater code referenced pyserial's VTIMESerial; our Serial is compatible.
+VTIMESerial = Serial
+
+__all__ = ["Serial", "SerialException", "VTIMESerial"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Drivers hit this during AGNOS updates:

```
ModuleNotFoundError: No module named 'serial'
```

The prebuilt AGNOS updater zipapp (`openpilot/common/hardware/comma/updater`, LFS) still imports `pyserial`, which was removed upstream in #38311. Rebuilding that blob requires GitLab LFS access most forks do not have.

## No-LFS workaround

Add a tiny `serial/` package at the repo root that re-exports `openpilot.common.serial`:

- `serial/__init__.py` — provides `Serial`, `SerialException`, and `VTIMESerial`
- `launch_chffrplus.sh` — ensures repo root is on `PYTHONPATH` before the updater runs during AGNOS init

This is plain git text — no LFS changes, no new pip dependencies, no updater rebuild. After pulling this branch, the stale zipapp can `import serial` from the shim.

## Branch impact

`sp-honda-dev-202608` and `chestnut` both ship the same updater LFS blob, so both are affected.

Check device branch with:
```bash
cat /data/params/d/GitBranch
```

## Manual cherry-pick (if not merging the PR)

If you just want the minimal patch on your fork:

1. Add `serial/__init__.py` (see this PR)
2. In `launch_chffrplus.sh`, inside `agnos_init` before running the updater:
   ```bash
   export PYTHONPATH="$DIR${PYTHONPATH:+:$PYTHONPATH}"
   ```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a9d2f4b-69d5-460e-a47b-10e941fd5bbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a9d2f4b-69d5-460e-a47b-10e941fd5bbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

