### PR TITLE
Fix serial shim when updater zipapp shadows openpilot

### DIFF
--- a/openpilot/common/hardware/comma/tests/test_serial_shim.py
+++ b/openpilot/common/hardware/comma/tests/test_serial_shim.py
@@ -1,20 +1,46 @@
 import importlib
 import sys
+import types
 import unittest
+import zipfile
+from pathlib import Path
 from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+UPDATER = REPO_ROOT / "openpilot/common/hardware/comma/updater"
 
 
 class TestSerialShim(unittest.TestCase):
   def test_serial_shim_exports(self):
-    # Simulate device boot: repo root on PYTHONPATH, no pyserial installed.
     with patch.dict(sys.modules, {"serial": None}):
       sys.modules.pop("serial", None)
       serial = importlib.import_module("serial")
       from openpilot.common.serial import Serial, SerialException
 
-      self.assertIs(serial.Serial, Serial)
-      self.assertIs(serial.SerialException, SerialException)
-      self.assertIs(serial.VTIMESerial, Serial)
+      self.assertEqual(serial.Serial.__name__, Serial.__name__)
+      self.assertEqual(serial.SerialException.__name__, SerialException.__name__)
+      self.assertIs(serial.VTIMESerial, serial.Serial)
+
+  def test_serial_shim_with_updater_shadowing_openpilot(self):
+    if not UPDATER.is_file() or UPDATER.read_bytes()[:2] != b"PK":
+      self.skipTest("updater zipapp not available")
+
+    # The zipapp bundles openpilot/ without common/serial.py, which shadows the
+    # live checkout when both are on sys.path.
+    fake_openpilot = types.ModuleType("openpilot")
+    fake_openpilot.__path__ = []  # type: ignore[attr-defined]
+    sys.modules["openpilot"] = fake_openpilot
+
+    try:
+      sys.modules.pop("serial", None)
+      serial = importlib.import_module("serial")
+      self.assertTrue(callable(serial.Serial))
+      self.assertTrue(issubclass(serial.SerialException, OSError))
+      self.assertIs(serial.VTIMESerial, serial.Serial)
+    finally:
+      sys.modules.pop("serial", None)
+      sys.modules.pop("openpilot", None)
 
 
 if __name__ == "__main__":

--- a/openpilot/common/hardware/comma/tests/test_serial_shim.py
+++ b/openpilot/common/hardware/comma/tests/test_serial_shim.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 import types
 import unittest
-import zipfile
 from pathlib import Path
 from unittest.mock import patch
 

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -1,10 +1,22 @@
 """Pyserial compatibility shim for the prebuilt AGNOS updater zipapp.
 
 Upstream removed pyserial (#38311) in favor of openpilot.common.serial, but the
-updater LFS blob was never rebuilt and still does `import serial`. Putting this
-package on PYTHONPATH lets that stale binary keep working without LFS access.
+updater LFS blob was never rebuilt and still does `import serial`. The zipapp
+also bundles a stale openpilot tree that shadows the live checkout, so this
+shim loads serial.py from disk instead of importing openpilot.common.serial.
 """
-from openpilot.common.serial import Serial, SerialException
+import importlib.util
+from pathlib import Path
+
+_SERIAL_PATH = Path(__file__).resolve().parent.parent / "openpilot" / "common" / "serial.py"
+_spec = importlib.util.spec_from_file_location("_openpilot_common_serial", _SERIAL_PATH)
+if _spec is None or _spec.loader is None:
+  raise ImportError(f"serial shim: could not load {_SERIAL_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+Serial = _mod.Serial
+SerialException = _mod.SerialException
 
 # Old updater code referenced pyserial's VTIMESerial; our Serial is compatible.
 VTIMESerial = Serial


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #168 fixed `ModuleNotFoundError: No module named 'serial'` but drivers still hit a new error on AGNOS update:

```
File "/data/openpilot/serial/__init__.py", line 7, in <module>
    from openpilot.common.serial import Serial, SerialException
ModuleNotFoundError: No module named 'openpilot.common.serial'
```

The `serial/` shim was found (PYTHONPATH fix worked), but the updater zipapp bundles a stale `openpilot/` tree **without** `common/serial.py`. Python resolves `openpilot` inside the zipapp first, so the shim's import fails.

## Fix

Load `openpilot/common/serial.py` from the live checkout by filesystem path via `importlib.util`, bypassing the zipapp's shadowed `openpilot` package.

## Test

Added `test_serial_shim_with_updater_shadowing_openpilot` that injects a fake `openpilot` module to reproduce the zipapp shadowing behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a9d2f4b-69d5-460e-a47b-10e941fd5bbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a9d2f4b-69d5-460e-a47b-10e941fd5bbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

