### PR TITLE
Add --pause-video flag to cabana

### DIFF
--- a/openpilot/tools/cabana/README.md
+++ b/openpilot/tools/cabana/README.md
@@ -26,6 +26,7 @@ Options:
   --data_dir <dir>          local directory with routes
   --no-vipc                 do not output video
   --no-cache                turn off the local route file cache
+  --pause-video             start with playback paused
   --dbc <file>              dbc file to open
 ```
 

--- a/openpilot/tools/cabana/tests/test_cabana_ui.py
+++ b/openpilot/tools/cabana/tests/test_cabana_ui.py
@@ -11,3 +11,4 @@ class TestCabanaUi(OpenpilotTestCase):
     result = subprocess.run(["./_cabana_ui", "-h"], cwd=CABANA_DIR, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
     assert "Usage:" in result.stderr
+    assert "--pause-video" in result.stderr

--- a/openpilot/tools/cabana/ui/app.cc
+++ b/openpilot/tools/cabana/ui/app.cc
@@ -180,7 +180,7 @@ std::vector<KeyEvent> takeKeyEvents() {
   return std::exchange(g_key_events, {});
 }
 
-int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file) {
+int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, bool start_paused) {
   try {
     // SIGINT/SIGTERM close all windows (which may ask about unsaved changes), then exit
     UnixSignalHandler signal_handler([]() { g_signal_exit = true; });
@@ -193,7 +193,7 @@ int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, cons
     inistate::load();
     inistate::applyWindowGeometry(glfw.window());
 
-    MainWindow win(glfw.window(), std::move(stream), std::move(stream_loader), dbc_file);
+    MainWindow win(glfw.window(), std::move(stream), std::move(stream_loader), dbc_file, start_paused);
     while (!win.exited()) {
       if (g_signal_exit.exchange(false)) {
         printf("\nexiting...\n");

--- a/openpilot/tools/cabana/ui/app.h
+++ b/openpilot/tools/cabana/ui/app.h
@@ -12,7 +12,7 @@ using StreamLoader = std::function<std::unique_ptr<AbstractStream>()>;
 
 // takes ownership of stream; a loader runs behind the window instead of before it; with neither, the
 // stream selector opens
-int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file);
+int run(std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, bool start_paused = false);
 
 // key presses with the modifier state at event time: imgui may apply a modifier release in the same frame as
 // the key press it belongs to, which loses fast shortcut sequences. Consumed once per frame by MainWindow.

--- a/openpilot/tools/cabana/ui/main.cc
+++ b/openpilot/tools/cabana/ui/main.cc
@@ -31,6 +31,7 @@ struct CabanaArgs {
   bool panda = false;
   bool no_vipc = false;
   bool no_cache = false;
+  bool pause_video = false;
   std::string panda_serial;
   std::string socketcan;
   std::string zmq;
@@ -63,6 +64,7 @@ void printUsage(const char *argv0) {
           "  --data_dir <dir>          local directory with routes\n"
           "  --no-vipc                 do not output video\n"
           "  --no-cache                turn off the local route file cache\n"
+          "  --pause-video             start with playback paused\n"
           "  --dbc <file>              dbc file to open\n",
           argv0);
 }
@@ -114,6 +116,8 @@ std::optional<int> parseArgs(int argc, char *argv[], CabanaArgs &args) {
       args.no_vipc = true;
     } else if (std::strcmp(a, "--no-cache") == 0) {
       args.no_cache = true;
+    } else if (std::strcmp(a, "--pause-video") == 0) {
+      args.pause_video = true;
     } else if (std::strcmp(a, "--dbc") == 0) {
       if (!takeValue(argc, argv, i, args.dbc)) return 1;
     } else if (a[0] == '-') {
@@ -198,5 +202,5 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  return run(std::move(stream), std::move(stream_loader), args.dbc);
+  return run(std::move(stream), std::move(stream_loader), args.dbc, args.pause_video);
 }

--- a/openpilot/tools/cabana/ui/mainwin.cc
+++ b/openpilot/tools/cabana/ui/mainwin.cc
@@ -36,7 +36,7 @@ constexpr const char *CHARTS_WINDOW = "Charts###ChartsWindow";
 }  // namespace
 
 MainWindow::MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader,
-                       const std::string &dbc_file) : window_(window) {
+                       const std::string &dbc_file, bool start_paused) : window_(window), start_paused_(start_paused) {
   can = &dummy_;
   video_splitter_ratio_ = inistate::main_window.video_splitter_ratio;
   messages_visible_ = inistate::main_window.messages_visible;
@@ -355,6 +355,10 @@ void MainWindow::startStream(std::unique_ptr<AbstractStream> stream, const std::
   stream_connections_.push_back(can->error.connect([](const std::string &msg) {
     MessageBox::warning("Error", msg);
   }));
+  if (start_paused_) {
+    can->pause(true);
+    start_paused_ = false;
+  }
   can->start();
 
   loadFile(dbc_file, SOURCE_ALL, [this]() {

--- a/openpilot/tools/cabana/ui/mainwin.h
+++ b/openpilot/tools/cabana/ui/mainwin.h
@@ -23,7 +23,7 @@ struct GLFWwindow;
 
 class MainWindow {
 public:
-  MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file);
+  MainWindow(GLFWwindow *window, std::unique_ptr<AbstractStream> stream, StreamLoader stream_loader, const std::string &dbc_file, bool start_paused = false);
   ~MainWindow();
   void draw();
   void toggleChartsDocking();
@@ -114,6 +114,7 @@ private:
   float video_splitter_ratio_ = -1.0f;  // < 0: the video widget is at its size hint
   std::vector<std::unique_ptr<ToolDialog>> tool_dialogs_;
   bool closing_ = false;
+  bool start_paused_ = false;
   bool exited_ = false;
   bool window_modified_ = false;
   struct StatusBar {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `--pause-video` command-line flag to cabana that starts playback in a paused state instead of autoplaying when a route or stream is opened from the CLI.

## Changes

- Parse `--pause-video` in `main.cc` and document it in the help text and README
- Pass the flag through `run()` into `MainWindow`
- In `startStream()`, pause the stream before calling `start()` on the first opened stream, then clear the flag so later streams opened from the UI behave normally
- Extend the cabana UI help test to assert the new flag appears in `--help` output

## Usage

```bash
cabana --demo --pause-video
cabana <route> --pause-video
```

## Notes

Pause is stream-wide in cabana (CAN timeline and video), matching the existing Space/play button behavior. The flag only affects the initial stream opened at launch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6bd6f48-a091-400e-aada-4480f0665aba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6bd6f48-a091-400e-aada-4480f0665aba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

