### PR TITLE
hardwared: import subprocess (fixes "ignition not recognized" on 0111-op-honda-dev)

### DIFF
--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -28,6 +28,30 @@ from openpilot.system.athena.registration import UNREGISTERED_DONGLE_ID
 
 ThermalStatus = log.DeviceState.ThermalStatus
 NetworkType = log.DeviceState.NetworkType
+
+
+class HondaCanIgnitionDetector:
+  """Fallback when the harness SBU line was classified notConnected at boot."""
+
+  def __init__(self) -> None:
+    self.prev_counter_326: int | None = None
+    self.prev_counter_1a6: int | None = None
+    self.ignition = False
+
+  def update(self, can_msgs) -> bool:
+    for msg in can_msgs:
+      if msg.src != 0 or len(msg.dat) < 8:
+        continue
+      counter = msg.dat[7] >> 4
+      if msg.address == 0x326:
+        if self.prev_counter_326 is not None and counter == (self.prev_counter_326 + 1) % 4:
+          self.ignition = bool((msg.dat[3] >> 4) & 1)  # SCM_FEEDBACK MAIN_ON
+        self.prev_counter_326 = counter
+      elif msg.address == 0x1A6:
+        if self.prev_counter_1a6 is not None and counter == (self.prev_counter_1a6 + 1) % 4:
+          self.ignition = bool(msg.dat[5] >> 7)  # alt SCM_BUTTONS MAIN_ON
+        self.prev_counter_1a6 = counter
+    return self.ignition
 NetworkStrength = log.DeviceState.NetworkStrength
 CURRENT_TAU = 15.   # 15s time constant
 TEMP_TAU = 5.   # 5s time constant
@@ -151,7 +175,8 @@ def hw_state_thread(end_event, hw_queue):
 
 def hardware_thread(end_event, hw_queue) -> None:
   pm = messaging.PubMaster(['deviceState'])
-  sm = messaging.SubMaster(["peripheralState", "gpsLocationExternal", "selfdriveState", "pandaStates"], poll="pandaStates")
+  sm = messaging.SubMaster(["peripheralState", "gpsLocationExternal", "selfdriveState", "pandaStates", "can"], poll="pandaStates")
+  honda_can_ignition = HondaCanIgnitionDetector()
 
   count = 0
 
@@ -220,7 +245,15 @@ def hardware_thread(end_event, hw_queue) -> None:
 
       in_car = pandaState.harnessStatus != log.PandaState.HarnessStatus.notConnected
 
-    elif (time.monotonic() - sm.recv_time['pandaStates']) > DISCONNECT_TIMEOUT:
+    # Honda CAN ignition fallback: if the harness was classified notConnected at boot (key off,
+    # both SBU lines high), panda won't read the ignition GPIO until orientation is re-detected.
+    if (not onroad_conditions["ignition"]) and sm.updated['can']:
+      if honda_can_ignition.update(sm['can']):
+        onroad_conditions["ignition"] = True
+        if len(pandaStates) > 0 and pandaStates[0].harnessStatus == log.PandaState.HarnessStatus.notConnected:
+          in_car = True
+
+    if (time.monotonic() - sm.recv_time['pandaStates']) > DISCONNECT_TIMEOUT:
       if onroad_conditions["ignition"]:
         onroad_conditions["ignition"] = False
         cloudlog.error("panda timed out onroad")

--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -3,6 +3,7 @@ import fcntl
 import os
 import queue
 import struct
+import subprocess
 import threading
 import time
 from collections import OrderedDict, namedtuple
@@ -28,30 +29,6 @@ from openpilot.system.athena.registration import UNREGISTERED_DONGLE_ID
 
 ThermalStatus = log.DeviceState.ThermalStatus
 NetworkType = log.DeviceState.NetworkType
-
-
-class HondaCanIgnitionDetector:
-  """Fallback when the harness SBU line was classified notConnected at boot."""
-
-  def __init__(self) -> None:
-    self.prev_counter_326: int | None = None
-    self.prev_counter_1a6: int | None = None
-    self.ignition = False
-
-  def update(self, can_msgs) -> bool:
-    for msg in can_msgs:
-      if msg.src != 0 or len(msg.dat) < 8:
-        continue
-      counter = msg.dat[7] >> 4
-      if msg.address == 0x326:
-        if self.prev_counter_326 is not None and counter == (self.prev_counter_326 + 1) % 4:
-          self.ignition = bool((msg.dat[3] >> 4) & 1)  # SCM_FEEDBACK MAIN_ON
-        self.prev_counter_326 = counter
-      elif msg.address == 0x1A6:
-        if self.prev_counter_1a6 is not None and counter == (self.prev_counter_1a6 + 1) % 4:
-          self.ignition = bool(msg.dat[5] >> 7)  # alt SCM_BUTTONS MAIN_ON
-        self.prev_counter_1a6 = counter
-    return self.ignition
 NetworkStrength = log.DeviceState.NetworkStrength
 CURRENT_TAU = 15.   # 15s time constant
 TEMP_TAU = 5.   # 5s time constant
@@ -175,8 +152,7 @@ def hw_state_thread(end_event, hw_queue):
 
 def hardware_thread(end_event, hw_queue) -> None:
   pm = messaging.PubMaster(['deviceState'])
-  sm = messaging.SubMaster(["peripheralState", "gpsLocationExternal", "selfdriveState", "pandaStates", "can"], poll="pandaStates")
-  honda_can_ignition = HondaCanIgnitionDetector()
+  sm = messaging.SubMaster(["peripheralState", "gpsLocationExternal", "selfdriveState", "pandaStates"], poll="pandaStates")
 
   count = 0
 
@@ -245,15 +221,7 @@ def hardware_thread(end_event, hw_queue) -> None:
 
       in_car = pandaState.harnessStatus != log.PandaState.HarnessStatus.notConnected
 
-    # Honda CAN ignition fallback: if the harness was classified notConnected at boot (key off,
-    # both SBU lines high), panda won't read the ignition GPIO until orientation is re-detected.
-    if (not onroad_conditions["ignition"]) and sm.updated['can']:
-      if honda_can_ignition.update(sm['can']):
-        onroad_conditions["ignition"] = True
-        if len(pandaStates) > 0 and pandaStates[0].harnessStatus == log.PandaState.HarnessStatus.notConnected:
-          in_car = True
-
-    if (time.monotonic() - sm.recv_time['pandaStates']) > DISCONNECT_TIMEOUT:
+    elif (time.monotonic() - sm.recv_time['pandaStates']) > DISCONNECT_TIMEOUT:
       if onroad_conditions["ignition"]:
         onroad_conditions["ignition"] = False
         cloudlog.error("panda timed out onroad")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On `0111-op-honda-dev` the comma 3X never goes onroad on the ACURA_RLX_HYBRID even though the same car, wiring, and startup sequence work on `000-mdx-pedaltest` (routes `a5cd616a92467aed/00000153--48f4b65d1a` and `a5cd616a92467aed/00000159--91e2155b48`, both `ignitionLine=True`, harness `flipped`).

## Root cause

`e56750fda` ("only run AGNOS power drop monitor when in a car") added to `system/hardware/hardwared.py`:

```python
subprocess.run(["sudo", "systemctl", action, "power_drop_monitor"], check=False)
```

but never added `import subprocess`. On `tici`/`tizi` the guarding condition (`in_car != in_car_prev`, with `in_car_prev = None`) is true on the very first loop iteration, so hardwared raises `NameError` immediately, manager restarts it, and it crash-loops. `deviceState.started` is never published as `True`, so nothing transitions onroad. The panda is reporting ignition correctly the whole time; the device just never acts on it — which presents as "comma won't recognize ignition".

`000-mdx-pedaltest` does not carry `e56750fda`, which is why it works. Both branches point at the same opendbc commit (`c11749d8f`) and the same panda commit, so this is not a safety/CAN/harness difference.

Verified with pyflakes: `hardwared.py` on `0111-op-honda-dev` reports `undefined name 'subprocess'`; pedaltest is clean.

## Fix

Add `import subprocess` to `system/hardware/hardwared.py`. One line.

The earlier revision of this PR added a Honda CAN-ignition fallback and an opendbc bump based on a harness-detection hypothesis; those are reverted here since they were not the cause and the fix should stay minimal and close to upstream. The opendbc submodule pointer is back at `c11749d8f` (unchanged from base).

## Note

`common/params_keys.h` on `0111-op-honda-dev` is missing the multi-band Honda Nidec keys (`HondaGasFactor00/10/20/30Params`, `HondaSpeedFactor05/15/25/35Params`, matching `*Alpha*` keys) that the shared opendbc `c11749d8f` carcontroller reads. That will likely crash `card` once the device does go onroad. Separate issue — happy to open a follow-up PR to port those keys from pedaltest.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d40f6d3d-a58f-4f6f-8578-534fbc91c3d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d40f6d3d-a58f-4f6f-8578-534fbc91c3d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

