### PR TITLE
Fix freeze at boot logo when switching to this branch from AGNOS 19.x branches

### DIFF
--- a/common/serial.py
+++ b/common/serial.py
@@ -1,0 +1,272 @@
+import errno
+import fcntl
+import os
+import select
+import struct
+import termios
+import time
+
+
+# Modem control lines (linux/termios.h); fall back to common x86_64 values.
+TIOCMBIS = getattr(termios, "TIOCMBIS", 0x5416)
+TIOCMBIC = getattr(termios, "TIOCMBIC", 0x5417)
+TIOCM_DTR = getattr(termios, "TIOCM_DTR", 0x002)
+TIOCM_RTS = getattr(termios, "TIOCM_RTS", 0x004)
+_TIOCM_DTR = struct.pack("I", TIOCM_DTR)
+_TIOCM_RTS = struct.pack("I", TIOCM_RTS)
+
+
+class SerialException(OSError):
+  pass
+
+
+class Serial:
+  def __init__(self, port: str, baudrate: int = 9600, timeout: float | None = None, *,
+               rtscts: bool = False, dsrdtr: bool = False, exclusive: bool = False):
+    self._port = port
+    self._baudrate = baudrate
+    self._timeout = timeout
+    self._rtscts = rtscts
+    self._dsrdtr = dsrdtr
+    self._exclusive = exclusive
+    self._dtr = True
+    self._fd = -1
+    self.open()
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args) -> None:
+    self.close()
+
+  @property
+  def fd(self) -> int:
+    self._ensure_open()
+    return self._fd
+
+  @property
+  def baudrate(self) -> int:
+    return self._baudrate
+
+  @baudrate.setter
+  def baudrate(self, value: int) -> None:
+    self._baudrate = int(value)
+    if self._fd >= 0:
+      self._configure()
+
+  @property
+  def dtr(self) -> bool:
+    return self._dtr
+
+  @dtr.setter
+  def dtr(self, value: bool) -> None:
+    self._dtr = bool(value)
+    if self._fd >= 0:
+      self._set_line(TIOCM_DTR, _TIOCM_DTR, self._dtr)
+
+  def open(self) -> None:
+    if self._fd >= 0:
+      return
+    try:
+      self._fd = os.open(self._port, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    except OSError as e:
+      self._fd = -1
+      raise SerialException(e.errno, f"could not open port {self._port}: {e}") from e
+
+    try:
+      if self._exclusive:
+        try:
+          fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as e:
+          raise SerialException(e.errno, f"could not exclusively lock port {self._port}: {e}") from e
+
+      self._configure()
+
+      # When not using hardware DSR/DTR handshaking, drive lines ourselves.
+      if not self._dsrdtr:
+        try:
+          self._set_line(TIOCM_DTR, _TIOCM_DTR, self._dtr)
+          if not self._rtscts:
+            self._set_line(TIOCM_RTS, _TIOCM_RTS, True)
+        except OSError as e:
+          if e.errno not in (errno.EINVAL, errno.ENOTTY):
+            raise
+
+      self.reset_input_buffer()
+    except BaseException:
+      self._close_fd()
+      raise
+
+  def close(self) -> None:
+    self._close_fd()
+
+  def read(self, size: int = 1) -> bytes:
+    self._ensure_open()
+    if size <= 0:
+      return b""
+
+    buf = bytearray()
+    deadline = self._deadline()
+    while len(buf) < size:
+      remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+      if not self._wait_readable(remaining):
+        break
+      try:
+        chunk = os.read(self._fd, size - len(buf))
+      except InterruptedError:
+        continue
+      except OSError as e:
+        if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+          if self._timeout == 0:
+            break
+          continue
+        raise SerialException(e.errno, f"read failed: {e}") from e
+      if not chunk:
+        break
+      buf.extend(chunk)
+    return bytes(buf)
+
+  def readline(self) -> bytes:
+    self._ensure_open()
+    buf = bytearray()
+    deadline = self._deadline()
+    while True:
+      remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+      if deadline is not None and remaining == 0.0 and not buf:
+        # match pyserial: timed-out readline returns empty
+        if not self._wait_readable(0.0):
+          return b""
+      elif not self._wait_readable(remaining):
+        return bytes(buf)
+
+      try:
+        chunk = os.read(self._fd, 1)
+      except InterruptedError:
+        continue
+      except OSError as e:
+        if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+          if self._timeout == 0:
+            return bytes(buf)
+          continue
+        raise SerialException(e.errno, f"read failed: {e}") from e
+      if not chunk:
+        return bytes(buf)
+      buf.extend(chunk)
+      if chunk == b"\n":
+        return bytes(buf)
+
+  def write(self, data: bytes) -> int:
+    self._ensure_open()
+    if not data:
+      return 0
+    view = memoryview(data)
+    total = 0
+    while total < len(data):
+      try:
+        n = os.write(self._fd, view[total:])
+      except InterruptedError:
+        continue
+      except OSError as e:
+        if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+          select.select([], [self._fd], [], None)
+          continue
+        raise SerialException(e.errno, f"write failed: {e}") from e
+      if n == 0:
+        raise SerialException("write returned 0")
+      total += n
+    return total
+
+  def flush(self) -> None:
+    self._ensure_open()
+    termios.tcdrain(self._fd)
+
+  def reset_input_buffer(self) -> None:
+    self._ensure_open()
+    termios.tcflush(self._fd, termios.TCIFLUSH)
+
+  def reset_output_buffer(self) -> None:
+    self._ensure_open()
+    termios.tcflush(self._fd, termios.TCOFLUSH)
+
+  def _close_fd(self) -> None:
+    if self._fd >= 0:
+      try:
+        if self._exclusive:
+          fcntl.flock(self._fd, fcntl.LOCK_UN)
+      except OSError:
+        pass
+      try:
+        os.close(self._fd)
+      except OSError:
+        pass
+      self._fd = -1
+
+  def _ensure_open(self) -> None:
+    if self._fd < 0:
+      raise SerialException("port is not open")
+
+  def _deadline(self) -> float | None:
+    if self._timeout is None:
+      return None
+    if self._timeout == 0:
+      return time.monotonic()
+    return time.monotonic() + self._timeout
+
+  def _wait_readable(self, timeout: float | None) -> bool:
+    """Return True if fd is readable. timeout None blocks; 0 polls."""
+    if timeout is not None and timeout < 0:
+      timeout = 0.0
+    try:
+      ready, _, _ = select.select([self._fd], [], [], timeout)
+    except InterruptedError:
+      return False
+    return bool(ready)
+
+  def _baud_constant(self, baudrate: int) -> int:
+    try:
+      return getattr(termios, f"B{baudrate}")
+    except AttributeError as e:
+      raise ValueError(f"unsupported baud rate: {baudrate}") from e
+
+  def _configure(self) -> None:
+    self._ensure_open()
+    try:
+      attrs = termios.tcgetattr(self._fd)
+    except termios.error as e:
+      raise SerialException(f"could not get port attributes: {e}") from e
+
+    iflag, oflag, cflag, lflag, _ispeed, _ospeed, cc = attrs
+
+    # raw binary 8N1
+    iflag = 0
+    oflag = 0
+    lflag = 0
+    cflag |= termios.CLOCAL | termios.CREAD
+    cflag &= ~termios.CSIZE
+    cflag |= termios.CS8
+    cflag &= ~(termios.PARENB | termios.PARODD | termios.CSTOPB)
+
+    if hasattr(termios, "CRTSCTS"):
+      if self._rtscts:
+        cflag |= termios.CRTSCTS
+      else:
+        cflag &= ~termios.CRTSCTS
+
+    speed = self._baud_constant(self._baudrate)
+    cc = list(cc)
+    # Non-blocking reads are handled via select + O_NONBLOCK; keep VMIN/VTIME at 0.
+    cc[termios.VMIN] = 0
+    cc[termios.VTIME] = 0
+
+    try:
+      termios.tcsetattr(self._fd, termios.TCSANOW, [iflag, oflag, cflag, lflag, speed, speed, cc])
+    except termios.error as e:
+      raise SerialException(f"could not configure port: {e}") from e
+
+    # Keep the fd non-blocking so timeout=0 and select work consistently.
+    flags = fcntl.fcntl(self._fd, fcntl.F_GETFL)
+    fcntl.fcntl(self._fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+  def _set_line(self, _bit: int, packed: bytes, enabled: bool) -> None:
+    request = TIOCMBIS if enabled else TIOCMBIC
+    fcntl.ioctl(self._fd, request, packed)

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -27,10 +27,25 @@ function agnos_init {
   if [ $(< /VERSION) != "$AGNOS_VERSION" ]; then
     AGNOS_PY="$DIR/system/hardware/tici/agnos.py"
     MANIFEST="$DIR/system/hardware/tici/agnos.json"
+    # We are running on a foreign AGNOS (e.g. after a branch switch). Newer AGNOS
+    # dropped pyserial, which agnos.py's import chain and the updater zipapp still
+    # need; only shim it in when the running OS really lacks it.
+    if ! python3 -c "import serial" 2> /dev/null; then
+      export PYTHONPATH="$DIR/system/hardware/tici/pyserial_compat${PYTHONPATH:+:$PYTHONPATH}"
+    fi
     if $AGNOS_PY --verify $MANIFEST; then
       sudo reboot
     fi
-    $DIR/system/hardware/tici/updater $AGNOS_PY $MANIFEST
+    # Never fall through to manager on a mismatched AGNOS; keep the updater UI up until
+    # it has flashed and rebooted us (same as upstream #38672). The updater normally
+    # reboots the device itself, so reaching the headless fallback means the UI died;
+    # if we have network, flash and swap without it.
+    while true; do
+      $DIR/system/hardware/tici/updater $AGNOS_PY $MANIFEST
+      if $AGNOS_PY --swap $MANIFEST; then
+        sudo reboot
+      fi
+    done
   fi
 }
 

--- a/system/hardware/comma/agnos.json
+++ b/system/hardware/comma/agnos.json
@@ -1,0 +1,1 @@
+../tici/agnos.json

--- a/system/hardware/tici/agnos.py
+++ b/system/hardware/tici/agnos.py
@@ -10,8 +10,6 @@ from collections.abc import Generator
 
 import requests
 
-import openpilot.system.updated.casync.casync as casync
-
 SPARSE_CHUNK_FMT = struct.Struct('H2xI4x')
 CAIBX_URL = "https://commadist.azureedge.net/agnosupdate/"
 
@@ -188,6 +186,11 @@ def extract_compressed_image(target_slot_number: int, partition: dict, cloudlog)
 
 
 def extract_casync_image(target_slot_number: int, partition: dict, cloudlog):
+  # casync pulls in swaglog -> system.hardware -> pyserial. Keep that out of the
+  # module import so `agnos.py --verify` can run on an AGNOS this branch wasn't
+  # built for (first boot after a branch switch), where those deps may be missing.
+  import openpilot.system.updated.casync.casync as casync
+
   path = get_partition_path(target_slot_number, partition)
   seed_path = path[:-1] + ('b' if path[-1] == 'a' else 'a')
 

--- a/system/hardware/tici/pyserial_compat/serial/__init__.py
+++ b/system/hardware/tici/pyserial_compat/serial/__init__.py
@@ -1,0 +1,35 @@
+"""Pyserial compatibility shim for running this branch on a newer AGNOS.
+
+AGNOS 19.x no longer ships pyserial (upstream dropped it in commaai/openpilot#38311),
+but this branch, and the prebuilt AGNOS updater zipapp it uses, still `import serial`
+through openpilot.system.hardware -> tici.lpa. When a device switches to this branch
+from a newer branch, the first boot runs this branch's code on the *newer* AGNOS until
+agnos.py --verify and the updater have flashed and swapped to the matching AGNOS. If
+`import serial` fails there, verify and the updater both crash and the device stays on
+the boot logo.
+
+launch_chffrplus.sh puts this directory's parent on PYTHONPATH only when the running
+AGNOS has no importable `serial` package, so the real pyserial is never shadowed on a
+matching AGNOS.
+
+The updater zipapp bundles a stale openpilot tree that shadows the live checkout, so the
+implementation is loaded from common/serial.py by path instead of importing
+openpilot.common.serial.
+"""
+import importlib.util
+from pathlib import Path
+
+_SERIAL_PATH = Path(__file__).resolve().parents[5] / "common" / "serial.py"
+_spec = importlib.util.spec_from_file_location("_openpilot_common_serial", _SERIAL_PATH)
+if _spec is None or _spec.loader is None:
+  raise ImportError(f"serial shim: could not load {_SERIAL_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+Serial = _mod.Serial
+SerialException = _mod.SerialException
+
+# pigeond and older updater builds reference pyserial's VTIMESerial; our Serial is compatible.
+VTIMESerial = Serial
+
+__all__ = ["Serial", "SerialException", "VTIMESerial"]

--- a/system/hardware/tici/tests/test_agnos_updater.py
+++ b/system/hardware/tici/tests/test_agnos_updater.py
@@ -4,9 +4,31 @@ import requests
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 MANIFEST = os.path.join(TEST_DIR, "../agnos.json")
+BASEDIR = os.path.abspath(os.path.join(TEST_DIR, "../../../.."))
+
+# All paths where an updater (past or present) may look for agnos.json when
+# switching to this branch. Must stay in sync with AGNOS_MANIFEST_PATHS in
+# system/updated/updated.py and with the sunnypilot-based branches' updaters.
+# Kept as symlinks to the real manifest so OTA branch switches from the nested
+# "openpilot/" layouts keep working.
+COMPAT_MANIFEST_PATHS = [
+  "system/hardware/tici/agnos.json",
+  "system/hardware/comma/agnos.json",
+  "openpilot/system/hardware/comma/agnos.json",
+  "openpilot/system/hardware/tici/agnos.json",
+]
 
 
 class TestAgnosUpdater:
+
+  def test_compat_manifest_paths(self):
+    real_manifest = os.path.realpath(MANIFEST)
+    for rel_path in COMPAT_MANIFEST_PATHS:
+      path = os.path.join(BASEDIR, rel_path)
+      assert os.path.isfile(path), f"{rel_path} missing or dangling symlink"
+      assert os.path.realpath(path) == real_manifest, f"{rel_path} does not resolve to {real_manifest}"
+      with open(path) as f:
+        json.load(f)
 
   def test_manifest(self):
     with open(MANIFEST) as f:

--- a/system/hardware/tici/tests/test_serial_shim.py
+++ b/system/hardware/tici/tests/test_serial_shim.py
@@ -1,0 +1,75 @@
+import importlib
+import re
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SHIM_DIR = REPO_ROOT / "system/hardware/tici/pyserial_compat"
+AGNOS_PY = REPO_ROOT / "system/hardware/tici/agnos.py"
+LAUNCH_SCRIPT = REPO_ROOT / "launch_chffrplus.sh"
+
+
+@pytest.fixture
+def shim_on_path(monkeypatch):
+  # simulate an AGNOS without pyserial, with the shim dir on PYTHONPATH as launch_chffrplus.sh does
+  saved_modules = dict(sys.modules)
+  monkeypatch.syspath_prepend(str(SHIM_DIR))
+  sys.modules.pop("serial", None)
+  yield
+  sys.modules.clear()
+  sys.modules.update(saved_modules)
+
+
+class TestSerialShim:
+  def test_shim_exports(self, shim_on_path):
+    serial = importlib.import_module("serial")
+    from openpilot.common.serial import Serial, SerialException
+
+    assert Path(serial.__file__).resolve() == (SHIM_DIR / "serial/__init__.py").resolve()
+    assert serial.Serial.__name__ == Serial.__name__
+    assert serial.SerialException.__name__ == SerialException.__name__
+    assert issubclass(serial.SerialException, OSError)
+    assert serial.VTIMESerial is serial.Serial
+
+  def test_shim_with_updater_shadowing_openpilot(self, shim_on_path):
+    # The updater zipapp bundles its own openpilot/ tree without common/serial.py,
+    # which shadows the live checkout when both are on sys.path.
+    fake_openpilot = types.ModuleType("openpilot")
+    fake_openpilot.__path__ = []  # type: ignore[attr-defined]
+    sys.modules["openpilot"] = fake_openpilot
+
+    serial = importlib.import_module("serial")
+    assert callable(serial.Serial)
+    assert issubclass(serial.SerialException, OSError)
+    assert serial.VTIMESerial is serial.Serial
+
+  def test_launch_script_points_at_shim(self):
+    # launch_chffrplus.sh must reference the directory that contains the serial/ package.
+    script = LAUNCH_SCRIPT.read_text()
+    m = re.search(r'PYTHONPATH="\$DIR/(?P<rel>[^"$:]+)\$\{PYTHONPATH', script)
+    assert m is not None, "pyserial shim PYTHONPATH export missing from launch_chffrplus.sh"
+    assert (REPO_ROOT / m.group("rel")).resolve() == SHIM_DIR.resolve()
+    assert (SHIM_DIR / "serial/__init__.py").is_file()
+    # the shim is only meant to fill in for a missing pyserial, never to shadow it
+    assert 'if ! python3 -c "import serial"' in script
+    # a crashing updater must not fall through to manager on a mismatched AGNOS
+    assert re.search(r"while true; do\s+\$DIR/system/hardware/tici/updater \$AGNOS_PY \$MANIFEST\s+if \$AGNOS_PY --swap \$MANIFEST", script)
+
+  def test_agnos_verify_does_not_need_pyserial(self):
+    # First boot after a branch switch runs `agnos.py --verify` on the *previous*
+    # branch's AGNOS, which may not ship pyserial (dropped in AGNOS 19.x). Loading
+    # the script must not drag in openpilot.system.hardware -> tici.lpa -> serial.
+    code = f"""
+import importlib.util, sys
+sys.modules['serial'] = None
+sys.modules['openpilot.system.hardware'] = None
+spec = importlib.util.spec_from_file_location('agnos_verify', {str(AGNOS_PY)!r})
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+assert callable(mod.verify_agnos_update) and callable(mod.flash_agnos_update)
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, cwd=REPO_ROOT)

--- a/system/updated/updated.py
+++ b/system/updated/updated.py
@@ -31,6 +31,26 @@ FINALIZED = os.path.join(STAGING_ROOT, "finalized")
 
 OVERLAY_INIT = Path(os.path.join(BASEDIR, ".overlay_init"))
 
+# Where agnos.json may live in the target checkout, depending on the target
+# branch's layout. Ordered from this branch's layout to the others we may switch
+# to. This branch keeps a symlink at system/hardware/comma/agnos.json so that
+# updaters running the newer nested "openpilot/" layout can also find our manifest.
+AGNOS_MANIFEST_PATHS = [
+  "system/hardware/tici/agnos.json",              # this layout
+  "openpilot/system/hardware/comma/agnos.json",   # nested openpilot/ layout, hardware/tici -> hardware/comma
+  "openpilot/common/hardware/comma/agnos.json",   # nested layout, real file location
+  "openpilot/system/hardware/tici/agnos.json",    # nested layout, pre tici -> comma rename
+  "selfdrive/hardware/tici/agnos.json",           # pre "rename selfdrive/hardware to system/hardware"
+]
+
+
+def get_agnos_manifest_path(basedir: str) -> str:
+  for rel_path in AGNOS_MANIFEST_PATHS:
+    manifest_path = os.path.join(basedir, rel_path)
+    if os.path.isfile(manifest_path):
+      return manifest_path
+  raise FileNotFoundError(f"no agnos.json found in {basedir}, tried: {AGNOS_MANIFEST_PATHS}")
+
 # do not allow to engage after this many hours onroad and this many routes
 HOURS_NO_CONNECTIVITY_MAX = 27
 ROUTES_NO_CONNECTIVITY_MAX = 84
@@ -220,7 +240,7 @@ def handle_agnos_update() -> None:
   cloudlog.info(f"Beginning background installation for AGNOS {updated_version}")
   set_offroad_alert("Offroad_NeosUpdate", True)
 
-  manifest_path = os.path.join(OVERLAY_MERGED, "system/hardware/tici/agnos.json")
+  manifest_path = get_agnos_manifest_path(OVERLAY_MERGED)
   target_slot_number = get_target_slot_number()
   flash_agnos_update(manifest_path, target_slot_number, cloudlog)
   set_offroad_alert("Offroad_NeosUpdate", False)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Description**

Devices switching from `sp-honda-dev-202608` (AGNOS 19.7) to `0111-op-honda-dev` (AGNOS 18.4) freeze on the comma boot logo.

The switch itself works: `updated.py` on the sp branch finds our manifest (via its `AGNOS_MANIFEST_PATHS` fallback from #154) and flashes AGNOS 18.4 into the inactive slot. The freeze happens on the first boot afterwards, which still runs on AGNOS 19.7 with our tree swapped in. `launch_chffrplus.sh` sees `/VERSION != 18.4` and runs `system/hardware/tici/agnos.py --verify`, which is supposed to confirm the flashed slot, `abctl --set_active` it, and reboot. On AGNOS 19.x that crashes before doing anything:

```
agnos.py -> casync/casync.py -> casync/common.py -> system/version.py -> common/swaglog.py
         -> system/hardware/__init__.py -> tici/hardware.py -> tici/lpa.py -> import serial
ModuleNotFoundError: No module named 'serial'
```

Upstream dropped pyserial from AGNOS in commaai/openpilot#38311 (AGNOS 19.x). From there the old launch script has no way out:

1. `--verify` exits 1, so launch runs `system/hardware/tici/updater`
2. `updater_magic` (the prebuilt zipapp) imports `openpilot.system.hardware` -> `lpa` -> `serial` and dies too
3. there was no loop around the updater (upstream added one in #38672), so launch fell through to `build.py` and `manager.py`, which import `HARDWARE` and die the same way
4. `while true; do sleep 1; done` -- boot logo forever, with a perfectly good AGNOS 18.4 sitting unbooted in the other slot

This is the mirror image of what #168/#169 fixed on `sp-honda-dev-202608`; this branch never got the equivalent, and it also never got the manifest-resolution port from #154.

**Changes**

- `system/hardware/tici/agnos.py`: import casync lazily inside `extract_casync_image`, so `--verify`/`--swap` only need the stdlib and `requests`.
- `launch_chffrplus.sh` (`agnos_init`, only reached when `/VERSION` mismatches):
  - probe `python3 -c "import serial"`; only if it fails, prepend `system/hardware/tici/pyserial_compat` to `PYTHONPATH`. Real pyserial is never shadowed on a matching AGNOS.
  - loop the updater (upstream #38672) instead of falling through to manager on a foreign OS, and fall back to headless `agnos.py --swap` if the updater UI dies.
- `common/serial.py` (vendored verbatim from upstream) + `system/hardware/tici/pyserial_compat/serial/__init__.py`: shim exporting `Serial`, `SerialException`, `VTIMESerial`, loading the implementation by path because the zipapp's bundled `openpilot` tree shadows the checkout.
- `system/updated/updated.py`: port of #154's `AGNOS_MANIFEST_PATHS` / `get_agnos_manifest_path` for this layout, plus a `system/hardware/comma/agnos.json -> ../tici/agnos.json` compat symlink so updaters on the nested `openpilot/` layout (which read `openpilot/system/hardware/comma/agnos.json`) can flash our AGNOS when switching here.

**Verification**

- Reproduced the failure on PC: with pyserial uninstalled, the original `agnos.py --help` dies with `ModuleNotFoundError: No module named 'serial'` via the chain above; the patched one runs.
- Downloaded the real `updater_magic` zipapp from comma's LFS and confirmed `import openpilot.system.hardware.tici.lpa` from inside it fails without pyserial and succeeds with only the shim on `PYTHONPATH`, including when the zipapp's `openpilot` package shadows the checkout.
- Simulated the `agnos_init` probe with a python lacking pyserial (shim gets added, `serial` resolves to the shim) and with pyserial present (`PYTHONPATH` untouched, real pyserial used).
- `get_agnos_manifest_path` resolves the manifest for both this layout and an extracted `sp-honda-dev-202608` tree, and raises clearly when none is found.
- New tests in `system/hardware/tici/tests/` (`test_serial_shim.py`, `test_compat_manifest_paths`) pass; `ruff check` clean on all touched files. `bash -n launch_chffrplus.sh` OK.

Not tested on a device; the flow to exercise is sp-honda-dev-202608 -> switch branch to 0111-op-honda-dev -> install -> first boot should show the AGNOS reboot (verify + swap) rather than sitting on the logo.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d7b818d-4d34-453b-b4d9-ee6540d37ecf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d7b818d-4d34-453b-b4d9-ee6540d37ecf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

