### PR TITLE
Auto-download default chestnut model at runtime

### DIFF
--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -255,6 +255,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"ModelManager_ActiveBundleChestnut", {PERSISTENT, JSON}},
     {"ModelManager_ActiveJson", {CLEAR_ON_MANAGER_START, JSON}},
     {"ModelManager_ClearCache", {CLEAR_ON_MANAGER_START, BOOL}},
+    {"ModelManager_DefaultChestnutOnnxHash", {PERSISTENT, STRING}},
     {"ModelManager_DownloadRef", {CLEAR_ON_MANAGER_START | CLEAR_ON_ONROAD_TRANSITION, STRING}},
     {"ModelManager_Favs", {PERSISTENT | BACKUP, STRING}},
     {"ModelManager_LastSyncTime", {CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION, INT, "0"}},

--- a/openpilot/sunnypilot/models/default_chestnut.py
+++ b/openpilot/sunnypilot/models/default_chestnut.py
@@ -1,0 +1,366 @@
+"""
+Runtime resolution and download of the stock chestnut driving model.
+
+Forks ship the big ONNX pointer but often omit the compiled tinygrad PKL chunks
+that stock modeld needs. When chestnut hardware is present, this module finds
+the matching artifact for the bundled ONNX and downloads it into MODELS_DIR.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import Path
+
+import requests
+
+from openpilot.cereal import custom
+from openpilot.common.file_chunker import get_manifest_path
+from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.modeld.helpers import MODELS_DIR, chestnut_compiled
+from openpilot.sunnypilot.models.helpers import get_selected_bundle, resolve_bundle_by_ref
+from openpilot.sunnypilot.models.tinygrad_ref import get_tinygrad_ref
+
+BIG_ONNX_PATH = MODELS_DIR / "big_driving_supercombo.onnx"
+CANONICAL_PKL = "big_driving_tinygrad.pkl"
+DEFAULT_MODEL_NAME_PATH = Path(__file__).resolve().parent / "model_name.py"
+ONNX_HASH_PARAM = "ModelManager_DefaultChestnutOnnxHash"
+HF_REPO = os.getenv("SUNNYPILOT_HF_MODEL_REPO", "sunnypilot/sunnypilot_models_v1")
+HF_DEFAULTS_PATH = os.getenv("SUNNYPILOT_HF_BIG_DEFAULTS_PATH", "models/defaults/big")
+HF_DEFAULTS_URL = f"https://huggingface.co/datasets/{HF_REPO}/resolve/main/{HF_DEFAULTS_PATH}/default_models.json"
+FETCH_TIMEOUT = 15
+# HF uploads and chestnut compiles often trail ONNX bumps by hours.
+RESOLVE_RETRY_BACKOFFS = (300, 600, 900, 3600)
+DOWNLOAD_RETRY_BACKOFFS = (60, 300, 900, 3600)
+
+
+def read_default_big_model_fields() -> dict[str, str]:
+  try:
+    content = DEFAULT_MODEL_NAME_PATH.read_text()
+  except OSError:
+    return {}
+  fields = {}
+  for line in content.splitlines():
+    if "=" in line:
+      key, val = line.split("=", 1)
+      fields[key.strip()] = val.strip().strip('"')
+  return fields
+
+
+def read_bundled_big_onnx_hash() -> str | None:
+  """Return the SHA256 of the bundled big ONNX, from LFS pointer or file contents."""
+  if not BIG_ONNX_PATH.is_file():
+    return None
+
+  try:
+    text = BIG_ONNX_PATH.read_text()
+  except OSError as e:
+    cloudlog.warning(f"Failed to read {BIG_ONNX_PATH}: {e}")
+    return None
+
+  if text.startswith("version https://git-lfs.github.com/spec/v1"):
+    for line in text.splitlines():
+      if line.startswith("oid sha256:"):
+        return line.split(":", 1)[1].strip().lower()
+    return None
+
+  import hashlib
+  digest = hashlib.sha256()
+  with open(BIG_ONNX_PATH, "rb") as f:
+    while block := f.read(1024 * 1024):
+      digest.update(block)
+  return digest.hexdigest().lower()
+
+
+def fetch_hf_defaults() -> dict | None:
+  try:
+    response = requests.get(HF_DEFAULTS_URL, timeout=FETCH_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+  except Exception as e:
+    cloudlog.warning(f"Failed to fetch HF default chestnut models from {HF_DEFAULTS_URL}: {e}")
+    return None
+
+
+def _warn_tinygrad_ref_mismatch(defaults: dict) -> None:
+  expected = get_tinygrad_ref()
+  actual = defaults.get("tinygrad_ref")
+  if expected and actual and expected != actual:
+    cloudlog.warning(f"HF defaults tinygrad_ref {actual} does not match repo {expected}; trying ONNX match anyway")
+
+
+def _bundle_for_onnx(defaults: dict, onnx_hash: str) -> dict | None:
+  for bundle in defaults.get("bundles", []):
+    if bundle.get("onnx_sha256", "").lower() == onnx_hash.lower():
+      return bundle
+  return None
+
+
+def _bundle_for_ref(defaults: dict, ref: str) -> dict | None:
+  for bundle in defaults.get("bundles", []):
+    if bundle.get("ref") == ref:
+      return bundle
+  return None
+
+
+def _bundle_for_model_name(defaults: dict, model_name: str) -> dict | None:
+  if not model_name:
+    return None
+  pattern = re.compile(model_name, re.IGNORECASE)
+  matches = [
+    bundle for bundle in defaults.get("bundles", [])
+    if pattern.search(bundle.get("display_name", "")) or pattern.search(bundle.get("short_name", ""))
+  ]
+  if not matches:
+    return None
+  return max(matches, key=lambda bundle: int(bundle.get("index", 0)))
+
+
+def _hf_bundle_matches_onnx(bundle: dict | None, onnx_hash: str | None) -> bool:
+  if bundle is None:
+    return False
+  if not onnx_hash:
+    return True
+  return bundle.get("onnx_sha256", "").lower() == onnx_hash.lower()
+
+
+def artifact_from_hf_bundle(bundle: dict, canonical_name: str = CANONICAL_PKL) -> custom.ModelManagerSP.Artifact | None:
+  models = bundle.get("models") or []
+  if not models:
+    return None
+
+  artifact_data = models[0].get("artifact") or {}
+  chunks_data = artifact_data.get("chunks") or []
+  download_uri = artifact_data.get("download_uri") or {}
+  pkl_url = download_uri.get("url")
+  if not pkl_url or not chunks_data:
+    return None
+
+  artifact = custom.ModelManagerSP.Artifact.new_message()
+  artifact.fileName = canonical_name
+  artifact.downloadUri.uri = pkl_url.rsplit("/", 1)[0] + "/" + canonical_name
+  artifact.downloadUri.sha256 = download_uri.get("sha256", "")
+
+  for chunk_data in chunks_data:
+    chunk = custom.ModelManagerSP.Chunk.new_message()
+    chunk.fileName = chunk_data.get("file_name", "")
+    chunk.sha256 = chunk_data.get("sha256", "")
+    artifact.chunks.append(chunk)
+
+  return artifact
+
+
+def artifact_from_manifest_bundle(bundle: custom.ModelManagerSP.ModelBundle,
+                                  canonical_name: str = CANONICAL_PKL) -> tuple[custom.ModelManagerSP.Artifact, str] | None:
+  drive_model = next((model for model in bundle.models if model.type == "supercombo"), None)
+  if drive_model is None or not drive_model.artifact.fileName:
+    return None
+
+  source = drive_model.artifact
+  artifact = custom.ModelManagerSP.Artifact.new_message()
+  artifact.fileName = source.fileName
+  artifact.downloadUri.uri = source.downloadUri.uri
+  artifact.downloadUri.sha256 = source.downloadUri.sha256
+  for chunk in source.chunks:
+    copied = custom.ModelManagerSP.Chunk.new_message()
+    copied.fileName = chunk.fileName
+    copied.sha256 = chunk.sha256
+    artifact.chunks.append(copied)
+
+  return artifact, source.fileName
+
+
+def promote_to_canonical(dest_dir: str | Path, source_name: str, canonical_name: str = CANONICAL_PKL) -> None:
+  if source_name == canonical_name:
+    return
+
+  dest = Path(dest_dir)
+  for path in sorted(dest.iterdir()):
+    if not path.is_file() or not path.name.startswith(source_name):
+      continue
+    path.rename(dest / path.name.replace(source_name, canonical_name, 1))
+
+
+def clear_stale_default_chestnut_artifacts(onnx_hash: str | None, params: Params | None = None) -> None:
+  """Drop cached default PKL chunks when the bundled ONNX hash changes."""
+  if not onnx_hash:
+    return
+
+  params = params or Params()
+  cached_hash = params.get(ONNX_HASH_PARAM)
+  if cached_hash == onnx_hash and chestnut_compiled():
+    return
+
+  if cached_hash and cached_hash != onnx_hash:
+    cloudlog.warning(f"Bundled big ONNX changed ({cached_hash[:12]} -> {onnx_hash[:12]}); clearing stale default chestnut model")
+    base = str(MODELS_DIR / CANONICAL_PKL)
+    for path in Path(MODELS_DIR).glob(f"{CANONICAL_PKL}*"):
+      if path.is_file():
+        path.unlink()
+    manifest = get_manifest_path(base)
+    if os.path.isfile(manifest):
+      os.remove(manifest)
+
+  params.put(ONNX_HASH_PARAM, onnx_hash, block=True)
+
+
+def resolve_bundle_from_manifest(source_models: dict[str, list[custom.ModelManagerSP.ModelBundle]],
+                                 fields: dict[str, str]) -> custom.ModelManagerSP.ModelBundle | None:
+  chestnut_bundles = source_models.get("chestnut", [])
+  ref = fields.get("DEFAULT_BIG_MODEL_REF", "")
+  if ref:
+    resolved = resolve_bundle_by_ref(ref, source_models)
+    if resolved is not None:
+      bundle, source = resolved
+      if source == "chestnut":
+        return bundle
+
+  model_name = fields.get("DEFAULT_BIG_MODEL", "")
+  if not model_name:
+    return None
+
+  pattern = re.compile(model_name, re.IGNORECASE)
+  matches = [
+    bundle for bundle in chestnut_bundles
+    if pattern.search(bundle.displayName) or pattern.search(bundle.internalName)
+  ]
+  if not matches:
+    return None
+  return max(matches, key=lambda bundle: bundle.index)
+
+
+def resolve_default_chestnut_artifact(
+  source_models: dict[str, list[custom.ModelManagerSP.ModelBundle]],
+) -> tuple[custom.ModelManagerSP.Artifact, str | None] | None:
+  """
+  Resolve the stock chestnut PKL artifact for this fork.
+
+  Returns (artifact, source_name_to_promote) where source_name_to_promote is set
+  when the downloaded files must be renamed to the canonical stock path.
+  """
+  onnx_hash = read_bundled_big_onnx_hash()
+  fields = read_default_big_model_fields()
+  defaults = fetch_hf_defaults()
+
+  if defaults:
+    _warn_tinygrad_ref_mismatch(defaults)
+
+    if onnx_hash:
+      bundle = _bundle_for_onnx(defaults, onnx_hash)
+      if bundle:
+        artifact = artifact_from_hf_bundle(bundle)
+        if artifact is not None:
+          cloudlog.info(f"Resolved default chestnut model from HF for ONNX {onnx_hash[:12]}")
+          return artifact, None
+      cloudlog.warning(f"No HF default chestnut model for ONNX {onnx_hash[:12]}")
+
+    model_name = fields.get("DEFAULT_BIG_MODEL", "")
+    name_bundle = _bundle_for_model_name(defaults, model_name)
+    if name_bundle is not None and _hf_bundle_matches_onnx(name_bundle, onnx_hash):
+      artifact = artifact_from_hf_bundle(name_bundle)
+      if artifact is not None:
+        cloudlog.info(f"Resolved default chestnut model from HF for {model_name}")
+        return artifact, None
+    elif name_bundle is not None and onnx_hash:
+      cloudlog.warning(f"HF bundle for {model_name} does not match bundled ONNX {onnx_hash[:12]}")
+
+  manifest_bundle = resolve_bundle_from_manifest(source_models, fields)
+  if manifest_bundle is None:
+    return None
+
+  ref = manifest_bundle.ref
+  if onnx_hash and defaults:
+    hf_bundle = _bundle_for_ref(defaults, ref)
+    if not _hf_bundle_matches_onnx(hf_bundle, onnx_hash):
+      cloudlog.warning(f"Refusing manifest fallback for ref {ref}: HF ONNX does not match bundled {onnx_hash[:12]}")
+      return None
+  elif onnx_hash and defaults is None:
+    cloudlog.warning("Cannot verify manifest fallback without HF metadata; waiting for HF defaults")
+    return None
+
+  parsed = artifact_from_manifest_bundle(manifest_bundle)
+  if parsed is None:
+    return None
+
+  artifact, original_name = parsed
+  promote_name = original_name if original_name != CANONICAL_PKL else None
+  cloudlog.info(f"Resolved default chestnut model from manifest ref {ref}")
+  return artifact, promote_name
+
+
+def needs_default_chestnut_download(params: Params | None = None, chestnut_present: bool = False) -> bool:
+  if not chestnut_present:
+    return False
+  if chestnut_compiled():
+    return False
+  if get_selected_bundle(params, "chestnut") is not None:
+    return False
+  return True
+
+
+class DefaultChestnutDownloader:
+  """Downloads the stock chestnut model into MODELS_DIR with retry backoff."""
+
+  def __init__(self):
+    self._resolve_failures = 0
+    self._download_failures = 0
+    self._next_attempt = 0.0
+    self._in_progress = False
+
+  def should_attempt(self) -> bool:
+    return not self._in_progress and time.monotonic() >= self._next_attempt
+
+  def mark_resolve_failure(self) -> None:
+    self._resolve_failures += 1
+    delay = RESOLVE_RETRY_BACKOFFS[min(self._resolve_failures - 1, len(RESOLVE_RETRY_BACKOFFS) - 1)]
+    self._next_attempt = time.monotonic() + delay
+    cloudlog.warning(f"Default chestnut model not available yet; retrying in {delay}s")
+
+  def mark_download_failure(self) -> None:
+    self._download_failures += 1
+    delay = DOWNLOAD_RETRY_BACKOFFS[min(self._download_failures - 1, len(DOWNLOAD_RETRY_BACKOFFS) - 1)]
+    self._next_attempt = time.monotonic() + delay
+    cloudlog.warning(f"Default chestnut model download failed; retrying in {delay}s")
+
+  def mark_success(self) -> None:
+    self._resolve_failures = 0
+    self._download_failures = 0
+    self._next_attempt = 0.0
+
+  @property
+  def in_progress(self) -> bool:
+    return self._in_progress
+
+  def run(self, manager, source_models: dict[str, list[custom.ModelManagerSP.ModelBundle]], params: Params) -> bool:
+    if self._in_progress:
+      return False
+
+    onnx_hash = read_bundled_big_onnx_hash()
+    clear_stale_default_chestnut_artifacts(onnx_hash, params)
+
+    resolved = resolve_default_chestnut_artifact(source_models)
+    if resolved is None:
+      self.mark_resolve_failure()
+      return False
+
+    artifact, promote_name = resolved
+    self._in_progress = True
+    try:
+      import asyncio
+      asyncio.run(manager._process_artifact(artifact, str(MODELS_DIR)))
+      if promote_name:
+        promote_to_canonical(MODELS_DIR, promote_name)
+      if chestnut_compiled():
+        if onnx_hash:
+          params.put(ONNX_HASH_PARAM, onnx_hash, block=True)
+        cloudlog.info("Default chestnut model is available in MODELS_DIR")
+        self.mark_success()
+        return True
+      raise RuntimeError("download finished but chestnut model is still missing")
+    except Exception:
+      self.mark_download_failure()
+      raise
+    finally:
+      self._in_progress = False

--- a/openpilot/sunnypilot/models/manager.py
+++ b/openpilot/sunnypilot/models/manager.py
@@ -15,7 +15,8 @@ from openpilot.common.realtime import Ratekeeper
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.hardware.hw import Paths
 
-from openpilot.cereal import messaging, custom
+from openpilot.cereal import log, messaging, custom
+from openpilot.sunnypilot.models.default_chestnut import DefaultChestnutDownloader, needs_default_chestnut_download
 from openpilot.sunnypilot.models.fetcher import ModelFetcher
 from openpilot.sunnypilot.models.helpers import (ACTIVE_BUNDLE_KEYS, get_active_bundle, get_selected_bundle,
                                                   resolve_bundle_by_ref, validate_active_bundles, verify_file)
@@ -44,6 +45,7 @@ class ModelManagerSP:
     self._chunk_size = 128 * 1000  # 128 KB chunks
     self._download_start_times: dict[str, float] = {}  # Track start time per model
     self._download_ref: bytes | str | None = None
+    self._default_chestnut = DefaultChestnutDownloader()
 
   def _download_interrupted(self) -> bool:
     # only removal cancels: a different ref is a queued selection that
@@ -294,6 +296,26 @@ class ModelManagerSP:
     """Main entry point for downloading a model bundle"""
     asyncio.run(self._download_bundle(model_bundle, destination_path, source))
 
+  def _ensure_default_chestnut_model(self) -> None:
+    if not needs_default_chestnut_download(self.params, self.chestnut_present):
+      return
+    if self.params.get("ModelManager_DownloadRef") is not None:
+      return
+    if not self._default_chestnut.should_attempt():
+      return
+
+    network_type = self.sm['deviceState'].networkType
+    if network_type == log.DeviceState.NetworkType.none:
+      return
+    if self.sm['deviceState'].networkMetered:
+      cloudlog.debug("Skipping default chestnut model download on metered network")
+      return
+
+    try:
+      self._default_chestnut.run(self, self.source_models, self.params)
+    except Exception as e:
+      cloudlog.exception(f"Default chestnut model download failed: {e}")
+
   def _process_download_requests(self) -> None:
     # loops so a ref queued during a download starts in the same tick, without
     # the bar dropping to idle for a tick between the two transfers
@@ -335,6 +357,7 @@ class ModelManagerSP:
               self.params.put("ModelManager_DownloadRef", DEFAULT_MODEL_REF)
 
         self._process_download_requests()
+        self._ensure_default_chestnut_model()
 
         if self.params.get("ModelManager_ClearCache"):
           self.clear_model_cache()

--- a/openpilot/sunnypilot/models/tests/test_default_chestnut.py
+++ b/openpilot/sunnypilot/models/tests/test_default_chestnut.py
@@ -1,0 +1,237 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+import os
+import tempfile
+import typing
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openpilot.cereal import custom
+from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.sunnypilot.models.default_chestnut import (
+  CANONICAL_PKL,
+  DefaultChestnutDownloader,
+  artifact_from_hf_bundle,
+  clear_stale_default_chestnut_artifacts,
+  needs_default_chestnut_download,
+  promote_to_canonical,
+  read_bundled_big_onnx_hash,
+  resolve_default_chestnut_artifact,
+)
+
+
+LFS_POINTER = """version https://git-lfs.github.com/spec/v1
+oid sha256:1791d5940b2c048d0639813426dd2cf1d6f2a6727ed51e17c8bcea8bbe754123
+size 765950064
+"""
+
+LEBOWSKI_ONNX = "a501760a9d1d5fef0eab2b8c5d122d06124fc26dc8e0782e0aa94b82a208f0ff"
+BMRLNAP_ONNX = LFS_POINTER.split("oid sha256:", maxsplit=1)[1].split(maxsplit=1)[0]
+
+
+HF_DEFAULTS = {
+  "tinygrad_ref": "abc123",
+  "bundles": [
+    {
+      "index": 0,
+      "short_name": "LEBOWSKI",
+      "display_name": "Lebowski",
+      "ref": "lebowski-ref",
+      "onnx_sha256": LEBOWSKI_ONNX,
+      "models": [{
+        "artifact": {
+          "file_name": "driving_lebowski_tinygrad.pkl",
+          "download_uri": {
+            "url": "https://hf.example/lebowski/driving_lebowski_tinygrad.pkl",
+            "sha256": "deadbeef",
+          },
+          "chunks": [
+            {"file_name": "driving_lebowski_tinygrad.pkl.chunk01of02", "sha256": "aa"},
+            {"file_name": "driving_lebowski_tinygrad.pkl.chunk02of02", "sha256": "bb"},
+          ],
+        },
+      }],
+    },
+    {
+      "index": 1,
+      "short_name": "BMRLNAP",
+      "display_name": "BMRLNAP Model v4",
+      "ref": "bmrlnap-ref",
+      "onnx_sha256": BMRLNAP_ONNX,
+      "models": [{
+        "artifact": {
+          "file_name": "big_driving_tinygrad.pkl",
+          "download_uri": {
+            "url": "https://hf.example/bmrlnap/big_driving_tinygrad.pkl",
+            "sha256": "deadbeef",
+          },
+          "chunks": [
+            {"file_name": "big_driving_tinygrad.pkl.chunk01of02", "sha256": "aa"},
+            {"file_name": "big_driving_tinygrad.pkl.chunk02of02", "sha256": "bb"},
+          ],
+        },
+      }],
+    },
+  ],
+}
+
+
+class TestDefaultChestnutHelpers(OpenpilotTestCase):
+  def test_read_bundled_big_onnx_hash_from_lfs_pointer(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      onnx_path = Path(tmp) / "big_driving_supercombo.onnx"
+      onnx_path.write_text(LFS_POINTER)
+      with mock.patch("openpilot.sunnypilot.models.default_chestnut.BIG_ONNX_PATH", onnx_path):
+        assert read_bundled_big_onnx_hash() == BMRLNAP_ONNX
+
+  def test_artifact_from_hf_bundle(self):
+    bundle = typing.cast(dict, HF_DEFAULTS["bundles"][1])
+    artifact = artifact_from_hf_bundle(bundle)
+    assert artifact.fileName == CANONICAL_PKL
+    assert artifact.downloadUri.uri.endswith("/big_driving_tinygrad.pkl")
+    assert len(artifact.chunks) == 2
+
+  def test_promote_to_canonical(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      source = "driving_custom_tinygrad.pkl"
+      manifest = get_manifest_path(source)
+      chunk = get_chunk_name(source, 0, 1)
+      Path(tmp, manifest).write_text("1")
+      Path(tmp, chunk).write_text("data")
+
+      promote_to_canonical(tmp, source, CANONICAL_PKL)
+
+      assert Path(tmp, get_manifest_path(CANONICAL_PKL)).is_file()
+      assert Path(tmp, get_chunk_name(CANONICAL_PKL, 0, 1)).is_file()
+
+  def test_clear_stale_default_chestnut_artifacts(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      models_dir = Path(tmp)
+      manifest = models_dir / get_manifest_path(CANONICAL_PKL)
+      chunk = models_dir / get_chunk_name(CANONICAL_PKL, 0, 1)
+      manifest.write_text("1")
+      chunk.write_text("old")
+
+      params = mock.MagicMock()
+      params.get.return_value = LEBOWSKI_ONNX
+
+      with mock.patch("openpilot.sunnypilot.models.default_chestnut.MODELS_DIR", models_dir), \
+           mock.patch("openpilot.sunnypilot.models.default_chestnut.chestnut_compiled", return_value=True):
+        clear_stale_default_chestnut_artifacts(BMRLNAP_ONNX, params)
+
+      assert not manifest.exists()
+      assert not chunk.exists()
+      params.put.assert_called()
+
+  def test_needs_default_chestnut_download(self):
+    params = mock.MagicMock()
+    params.get.return_value = None
+    with mock.patch("openpilot.sunnypilot.models.default_chestnut.chestnut_compiled", return_value=False):
+      assert needs_default_chestnut_download(params, chestnut_present=True) is True
+
+    params.get.return_value = {"ref": "custom"}
+    with mock.patch("openpilot.sunnypilot.models.default_chestnut.chestnut_compiled", return_value=False):
+      assert needs_default_chestnut_download(params, chestnut_present=True) is False
+
+
+class TestResolveDefaultChestnutArtifact(OpenpilotTestCase):
+  def test_prefers_hf_onnx_hash_match(self):
+    with mock.patch("openpilot.sunnypilot.models.default_chestnut.read_bundled_big_onnx_hash", return_value=BMRLNAP_ONNX), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.fetch_hf_defaults", return_value=HF_DEFAULTS), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.read_default_big_model_fields",
+                    return_value={"DEFAULT_BIG_MODEL": "BMRLNAP Model v4", "DEFAULT_BIG_MODEL_REF": "bmrlnap-ref"}):
+      resolved = resolve_default_chestnut_artifact({})
+      assert resolved is not None
+      artifact, promote_name = resolved
+      assert artifact.fileName == CANONICAL_PKL
+      assert promote_name is None
+
+  def test_hf_name_fallback_requires_onnx_match(self):
+    with mock.patch("openpilot.sunnypilot.models.default_chestnut.read_bundled_big_onnx_hash", return_value=BMRLNAP_ONNX), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.fetch_hf_defaults", return_value=HF_DEFAULTS), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.read_default_big_model_fields",
+                    return_value={"DEFAULT_BIG_MODEL": "BMRLNAP Model v4"}):
+      resolved = resolve_default_chestnut_artifact({})
+      assert resolved is not None
+
+  def test_refuses_manifest_when_hf_onnx_mismatches(self):
+    bundle = custom.ModelManagerSP.ModelBundle.new_message()
+    bundle.ref = "lebowski-ref"
+    bundle.displayName = "Lebowski"
+    bundle.internalName = "LEBOWSKI"
+    bundle.index = 0
+    model = bundle.models[0]
+    model.type = "supercombo"
+    model.artifact.fileName = CANONICAL_PKL
+    model.artifact.downloadUri.uri = "https://example.com/big_driving_tinygrad.pkl"
+    chunk = custom.ModelManagerSP.Chunk.new_message()
+    chunk.sha256 = "111"
+    model.artifact.chunks = [chunk]
+
+    with mock.patch("openpilot.sunnypilot.models.default_chestnut.read_bundled_big_onnx_hash", return_value=BMRLNAP_ONNX), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.fetch_hf_defaults", return_value=HF_DEFAULTS), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.read_default_big_model_fields",
+                    return_value={"DEFAULT_BIG_MODEL": "Lebowski", "DEFAULT_BIG_MODEL_REF": "lebowski-ref"}):
+      assert resolve_default_chestnut_artifact({"chestnut": [bundle]}) is None
+
+  def test_allows_manifest_when_hf_confirms_ref(self):
+    bundle = custom.ModelManagerSP.ModelBundle.new_message()
+    bundle.ref = "bmrlnap-ref"
+    bundle.displayName = "BMRLNAP Model v4"
+    bundle.internalName = "BMRLNAP"
+    bundle.index = 1
+    model = bundle.models[0]
+    model.type = "supercombo"
+    model.artifact.fileName = CANONICAL_PKL
+    model.artifact.downloadUri.uri = "https://example.com/big_driving_tinygrad.pkl"
+    chunk = custom.ModelManagerSP.Chunk.new_message()
+    chunk.sha256 = "111"
+    model.artifact.chunks = [chunk]
+
+    with mock.patch("openpilot.sunnypilot.models.default_chestnut.read_bundled_big_onnx_hash", return_value=BMRLNAP_ONNX), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.fetch_hf_defaults", return_value=HF_DEFAULTS), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.read_default_big_model_fields",
+                    return_value={"DEFAULT_BIG_MODEL": "BMRLNAP Model v4", "DEFAULT_BIG_MODEL_REF": "bmrlnap-ref"}), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut._bundle_for_onnx", return_value=None):
+      resolved = resolve_default_chestnut_artifact({"chestnut": [bundle]})
+      assert resolved is not None
+
+
+class TestDefaultChestnutDownloader(OpenpilotTestCase):
+  def test_run_promotes_manifest_artifacts(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      downloader = DefaultChestnutDownloader()
+      manager = mock.MagicMock()
+      params = mock.MagicMock()
+
+      def write_fake_chunks(destination, source):
+        with open(os.path.join(destination, get_manifest_path(source)), "w") as f:
+          f.write("1")
+        with open(os.path.join(destination, get_chunk_name(source, 0, 1)), "w") as f:
+          f.write("data")
+
+      async def fake_process(artifact, destination):
+        write_fake_chunks(destination, artifact.fileName)
+
+      manager._process_artifact = fake_process
+      artifact = custom.ModelManagerSP.Artifact.new_message()
+      artifact.fileName = "driving_custom_tinygrad.pkl"
+      resolved = (artifact, "driving_custom_tinygrad.pkl")
+
+      with mock.patch("openpilot.sunnypilot.models.default_chestnut.resolve_default_chestnut_artifact", return_value=resolved), \
+           mock.patch("openpilot.sunnypilot.models.default_chestnut.clear_stale_default_chestnut_artifacts"), \
+           mock.patch("openpilot.sunnypilot.models.default_chestnut.MODELS_DIR", Path(tmp)), \
+           mock.patch("openpilot.sunnypilot.models.default_chestnut.chestnut_compiled") as compiled:
+        compiled.side_effect = lambda: Path(tmp, get_manifest_path(CANONICAL_PKL)).is_file()
+        assert downloader.run(manager, {}, params) is True
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When chestnut hardware is present but stock `big_driving_tinygrad.pkl` chunks are missing, `models_manager` resolves and downloads the matching artifact into `MODELS_DIR` at runtime — so fork maintainers don't need to cherry-pick large prebuilt blob commits.

## Resolution (ONNX-anchored)

1. **HF by bundled ONNX hash** (primary — tracks upstream model bumps)
2. **HF by `DEFAULT_BIG_MODEL` name** (covers CI upload lag after ONNX changes)
3. **gh-pages manifest** by ref or name — only when HF confirms the bundle ONNX matches the repo (prevents stale-ref wrong-model downloads)
4. `tinygrad_ref` mismatch warns but does not block HF lookup

## Operational hardening

- Purges stale PKL chunks when bundled ONNX hash changes across OTAs
- Separate retry backoff: 5m+ for unresolved artifacts (HF build in flight), 1m+ for failed transfers
- Skips metered networks; resumes partial chunk downloads

## Fork configuration

- `SUNNYPILOT_HF_MODEL_REPO` (default: `sunnypilot/sunnypilot_models_v1`)
- `SUNNYPILOT_HF_BIG_DEFAULTS_PATH` (default: `models/defaults/big`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d4f3b77-adbb-40ef-91d9-fa5437b19f27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d4f3b77-adbb-40ef-91d9-fa5437b19f27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

