### PR TITLE
Fix post-merge CI failures from chestnut download PR

### DIFF
--- a/openpilot/selfdrive/controls/tests/test_lane_centering.py
+++ b/openpilot/selfdrive/controls/tests/test_lane_centering.py
@@ -1,8 +1,9 @@
 from types import SimpleNamespace
+import unittest
 
 import numpy as np
-import pytest
 
+from openpilot.common.test import OpenpilotTestCase
 from openpilot.selfdrive.controls.lib.lane_centering import LaneCenteringController
 
 
@@ -42,135 +43,123 @@ def _converge(model, *, offset=0.0, authority=1.0):
   return controller, output
 
 
-@pytest.mark.parametrize(
-  "kwargs",
-  [
-    {"enabled": False},
-    {"active": False},
-    {"valid": False},
-    {"speed": 4.9},
-  ],
-)
-def test_hard_gates_are_noop(kwargs):
-  assert _update(LaneCenteringController(), _model(left=-1.5, right=2.1), **kwargs) == 0.0
+class TestLaneCentering(OpenpilotTestCase):
+  def test_hard_gates_are_noop(self):
+    cases = [
+      {"enabled": False},
+      {"active": False},
+      {"valid": False},
+      {"speed": 4.9},
+    ]
+    for kwargs in cases:
+      with self.subTest(**kwargs):
+        assert _update(LaneCenteringController(), _model(left=-1.5, right=2.1), **kwargs) == 0.0
 
+  def test_lane_change_is_noop(self):
+    assert _update(LaneCenteringController(), _model(left=-1.5, right=2.1, lane_change=1)) == 0.0
 
-def test_lane_change_is_noop():
-  assert _update(LaneCenteringController(), _model(left=-1.5, right=2.1, lane_change=1)) == 0.0
-
-
-def test_turn_signal_fades_lane_centering_correction():
-  model = _model(left=-1.5, right=2.1)
-  controller, centered = _converge(model, authority=0.0)
-  fading = _update(controller, model, authority=0.0, pause_on_signal=True, turn_signal_active=True)
-  assert 0.0 < fading < centered
-
-  for _ in range(300):
+  def test_turn_signal_fades_lane_centering_correction(self):
+    model = _model(left=-1.5, right=2.1)
+    controller, centered = _converge(model, authority=0.0)
     fading = _update(controller, model, authority=0.0, pause_on_signal=True, turn_signal_active=True)
-  assert abs(fading) < 1e-6
+    assert 0.0 < fading < centered
 
+    for _ in range(300):
+      fading = _update(controller, model, authority=0.0, pause_on_signal=True, turn_signal_active=True)
+    assert abs(fading) < 1e-6
 
-def test_turn_signal_pause_can_be_disabled():
-  model = _model(left=-1.5, right=2.1)
-  _, output = _converge(model, authority=0.0)
-  controller, _ = _converge(model, authority=0.0)
-  signaled = _update(controller, model, authority=0.0, turn_signal_active=True)
-  assert signaled == pytest.approx(output, abs=1e-7)
+  def test_turn_signal_pause_can_be_disabled(self):
+    model = _model(left=-1.5, right=2.1)
+    _, output = _converge(model, authority=0.0)
+    controller, _ = _converge(model, authority=0.0)
+    signaled = _update(controller, model, authority=0.0, turn_signal_active=True)
+    assert abs(signaled - output) < 1e-7
 
+  def test_invalid_lane_confidence_is_rejected(self):
+    cases = [
+      ("prob", np.nan),
+      ("prob", 1.1),
+      ("std", np.nan),
+      ("std", -0.1),
+    ]
+    for field, value in cases:
+      with self.subTest(field=field, value=value):
+        model = _model(left=-1.5, right=2.1)
+        values = model.laneLineProbs if field == "prob" else model.laneLineStds
+        values[1] = value
+        assert _update(LaneCenteringController(), model) == 0.0
 
-@pytest.mark.parametrize(
-  "field,value",
-  [
-    ("prob", np.nan),
-    ("prob", 1.1),
-    ("std", np.nan),
-    ("std", -0.1),
-  ],
-)
-def test_invalid_lane_confidence_is_rejected(field, value):
-  model = _model(left=-1.5, right=2.1)
-  values = model.laneLineProbs if field == "prob" else model.laneLineStds
-  values[1] = value
-  assert _update(LaneCenteringController(), model) == 0.0
+  def test_input_must_cover_lookahead(self):
+    model = _model(left=-1.5, right=2.1)
+    model.laneLines[1].x = model.laneLines[1].x[:10]
+    model.laneLines[1].y = model.laneLines[1].y[:10]
+    assert _update(LaneCenteringController(), model) == 0.0
 
+  def test_lane_center_error_steers_toward_center(self):
+    _, right = _converge(_model(left=-1.5, right=2.1), authority=0.0)
+    _, left = _converge(_model(left=-2.1, right=1.5), authority=0.0)
+    assert right > 0.0
+    assert left < 0.0
 
-def test_input_must_cover_lookahead():
-  model = _model(left=-1.5, right=2.1)
-  model.laneLines[1].x = model.laneLines[1].x[:10]
-  model.laneLines[1].y = model.laneLines[1].y[:10]
-  assert _update(LaneCenteringController(), model) == 0.0
+  def test_small_center_error_does_not_chatter(self):
+    _, output = _converge(_model(left=-1.75, right=1.85), authority=0.0)
+    assert output == 0.0
 
+  def test_offset_direction(self):
+    _, right = _converge(_model(), offset=0.2, authority=0.0)
+    _, left = _converge(_model(), offset=-0.2, authority=0.0)
+    assert right > 0.0
+    assert left < 0.0
 
-def test_lane_center_error_steers_toward_center():
-  _, right = _converge(_model(left=-1.5, right=2.1), authority=0.0)
-  _, left = _converge(_model(left=-2.1, right=1.5), authority=0.0)
-  assert right > 0.0
-  assert left < 0.0
+  def test_offset_is_reduced_in_narrow_lane(self):
+    narrow = _model(left=-1.3, right=1.3)
+    _, at_safe_limit = _converge(narrow, offset=0.2, authority=0.0)
+    _, above_safe_limit = _converge(narrow, offset=0.3, authority=0.0)
+    assert np.isclose(at_safe_limit, above_safe_limit)
 
+  def test_confident_e2e_path_can_fully_break_in(self):
+    model = _model(left=-1.0, right=2.6, model_y=0.0, path_std=0.1)
+    _, lane_authority = _converge(model, authority=0.0)
+    _, e2e_authority = _converge(model, authority=1.0)
+    assert lane_authority > 0.0
+    assert abs(e2e_authority) < 1e-9
 
-def test_small_center_error_does_not_chatter():
-  _, output = _converge(_model(left=-1.75, right=1.85), authority=0.0)
-  assert output == 0.0
+  def test_uncertain_e2e_path_does_not_break_in(self):
+    model = _model(left=-1.0, right=2.6, model_y=0.0, path_std=0.6)
+    _, output = _converge(model, authority=1.0)
+    assert output > 0.0
 
+  def test_e2e_authority_blends_lane_correction(self):
+    model = _model(left=-1.2, right=2.4, model_y=0.0, path_std=0.1)
+    _, lane_only = _converge(model, authority=0.0)
+    _, blended = _converge(model, authority=0.5)
+    _, e2e = _converge(model, authority=1.0)
+    assert lane_only > blended > e2e >= 0.0
 
-def test_offset_direction():
-  _, right = _converge(_model(), offset=0.2, authority=0.0)
-  _, left = _converge(_model(), offset=-0.2, authority=0.0)
-  assert right > 0.0
-  assert left < 0.0
+  def test_confident_e2e_authority_starts_before_large_offset(self):
+    model = _model(left=-1.7, right=2.1, model_y=0.0, path_std=0.1)
+    _, lane_only = _converge(model, authority=0.0)
+    _, e2e = _converge(model, authority=1.0)
+    assert lane_only > e2e > 0.0
 
-
-def test_offset_is_reduced_in_narrow_lane():
-  narrow = _model(left=-1.3, right=1.3)
-  _, at_safe_limit = _converge(narrow, offset=0.2, authority=0.0)
-  _, above_safe_limit = _converge(narrow, offset=0.3, authority=0.0)
-  assert np.isclose(at_safe_limit, above_safe_limit)
-
-
-def test_confident_e2e_path_can_fully_break_in():
-  model = _model(left=-1.0, right=2.6, model_y=0.0, path_std=0.1)
-  _, lane_authority = _converge(model, authority=0.0)
-  _, e2e_authority = _converge(model, authority=1.0)
-  assert lane_authority > 0.0
-  assert abs(e2e_authority) < 1e-9
-
-
-def test_uncertain_e2e_path_does_not_break_in():
-  model = _model(left=-1.0, right=2.6, model_y=0.0, path_std=0.6)
-  _, output = _converge(model, authority=1.0)
-  assert output > 0.0
-
-
-def test_e2e_authority_blends_lane_correction():
-  model = _model(left=-1.2, right=2.4, model_y=0.0, path_std=0.1)
-  _, lane_only = _converge(model, authority=0.0)
-  _, blended = _converge(model, authority=0.5)
-  _, e2e = _converge(model, authority=1.0)
-  assert lane_only > blended > e2e >= 0.0
-
-
-def test_confident_e2e_authority_starts_before_large_offset():
-  model = _model(left=-1.7, right=2.1, model_y=0.0, path_std=0.1)
-  _, lane_only = _converge(model, authority=0.0)
-  _, e2e = _converge(model, authority=1.0)
-  assert lane_only > e2e > 0.0
-
-
-def test_confidence_loss_drops_filtered_correction():
-  controller, output = _converge(_model(left=-1.5, right=2.1), authority=0.0)
-  assert output > 0.0
-  fading = _update(controller, _model(left=-1.5, right=2.1, lane_prob=0.2), authority=0.0)
-  assert 0.0 < fading < output
-
-  for _ in range(300):
+  def test_confidence_loss_drops_filtered_correction(self):
+    controller, output = _converge(_model(left=-1.5, right=2.1), authority=0.0)
+    assert output > 0.0
     fading = _update(controller, _model(left=-1.5, right=2.1, lane_prob=0.2), authority=0.0)
-  assert abs(fading) < 1e-6
+    assert 0.0 < fading < output
+
+    for _ in range(300):
+      fading = _update(controller, _model(left=-1.5, right=2.1, lane_prob=0.2), authority=0.0)
+    assert abs(fading) < 1e-6
+
+  def test_correction_is_smoothed_and_capped(self):
+    controller = LaneCenteringController()
+    model = _model(left=0.0, right=3.0, path_std=0.6)
+    first = _update(controller, model, authority=0.0)
+    _, steady = _converge(model, authority=0.0)
+    assert 0.0 < first < steady
+    assert np.isclose(steady, 0.004 * 0.30, atol=1e-6)
 
 
-def test_correction_is_smoothed_and_capped():
-  controller = LaneCenteringController()
-  model = _model(left=0.0, right=3.0, path_std=0.6)
-  first = _update(controller, model, authority=0.0)
-  _, steady = _converge(model, authority=0.0)
-  assert 0.0 < first < steady
-  assert np.isclose(steady, 0.004 * 0.30, atol=1e-6)
+if __name__ == "__main__":
+  unittest.main()

--- a/openpilot/sunnypilot/models/default_chestnut.py
+++ b/openpilot/sunnypilot/models/default_chestnut.py
@@ -143,11 +143,11 @@ def artifact_from_hf_bundle(bundle: dict, canonical_name: str = CANONICAL_PKL) -
   artifact.downloadUri.uri = pkl_url.rsplit("/", 1)[0] + "/" + canonical_name
   artifact.downloadUri.sha256 = download_uri.get("sha256", "")
 
-  for chunk_data in chunks_data:
-    chunk = custom.ModelManagerSP.Chunk.new_message()
+  artifact.init('chunks', len(chunks_data))
+  for i, chunk_data in enumerate(chunks_data):
+    chunk = artifact.chunks[i]
     chunk.fileName = chunk_data.get("file_name", "")
     chunk.sha256 = chunk_data.get("sha256", "")
-    artifact.chunks.append(chunk)
 
   return artifact
 
@@ -163,11 +163,11 @@ def artifact_from_manifest_bundle(bundle: custom.ModelManagerSP.ModelBundle,
   artifact.fileName = source.fileName
   artifact.downloadUri.uri = source.downloadUri.uri
   artifact.downloadUri.sha256 = source.downloadUri.sha256
-  for chunk in source.chunks:
-    copied = custom.ModelManagerSP.Chunk.new_message()
+  artifact.init('chunks', len(source.chunks))
+  for i, chunk in enumerate(source.chunks):
+    copied = artifact.chunks[i]
     copied.fileName = chunk.fileName
     copied.sha256 = chunk.sha256
-    artifact.chunks.append(copied)
 
   return artifact, source.fileName
 

--- a/openpilot/sunnypilot/models/tests/test_default_chestnut.py
+++ b/openpilot/sunnypilot/models/tests/test_default_chestnut.py
@@ -136,8 +136,8 @@ class TestDefaultChestnutHelpers(OpenpilotTestCase):
     with mock.patch("openpilot.sunnypilot.models.default_chestnut.chestnut_compiled", return_value=False):
       assert needs_default_chestnut_download(params, chestnut_present=True) is True
 
-    params.get.return_value = {"ref": "custom"}
-    with mock.patch("openpilot.sunnypilot.models.default_chestnut.chestnut_compiled", return_value=False):
+    with mock.patch("openpilot.sunnypilot.models.default_chestnut.chestnut_compiled", return_value=False), \
+         mock.patch("openpilot.sunnypilot.models.default_chestnut.get_selected_bundle", return_value={"ref": "custom"}):
       assert needs_default_chestnut_download(params, chestnut_present=True) is False
 
 
@@ -167,13 +167,13 @@ class TestResolveDefaultChestnutArtifact(OpenpilotTestCase):
     bundle.displayName = "Lebowski"
     bundle.internalName = "LEBOWSKI"
     bundle.index = 0
+    bundle.init('models', 1)
     model = bundle.models[0]
     model.type = "supercombo"
     model.artifact.fileName = CANONICAL_PKL
     model.artifact.downloadUri.uri = "https://example.com/big_driving_tinygrad.pkl"
-    chunk = custom.ModelManagerSP.Chunk.new_message()
-    chunk.sha256 = "111"
-    model.artifact.chunks = [chunk]
+    model.artifact.init('chunks', 1)
+    model.artifact.chunks[0].sha256 = "111"
 
     with mock.patch("openpilot.sunnypilot.models.default_chestnut.read_bundled_big_onnx_hash", return_value=BMRLNAP_ONNX), \
          mock.patch("openpilot.sunnypilot.models.default_chestnut.fetch_hf_defaults", return_value=HF_DEFAULTS), \
@@ -187,13 +187,13 @@ class TestResolveDefaultChestnutArtifact(OpenpilotTestCase):
     bundle.displayName = "BMRLNAP Model v4"
     bundle.internalName = "BMRLNAP"
     bundle.index = 1
+    bundle.init('models', 1)
     model = bundle.models[0]
     model.type = "supercombo"
     model.artifact.fileName = CANONICAL_PKL
     model.artifact.downloadUri.uri = "https://example.com/big_driving_tinygrad.pkl"
-    chunk = custom.ModelManagerSP.Chunk.new_message()
-    chunk.sha256 = "111"
-    model.artifact.chunks = [chunk]
+    model.artifact.init('chunks', 1)
+    model.artifact.chunks[0].sha256 = "111"
 
     with mock.patch("openpilot.sunnypilot.models.default_chestnut.read_bundled_big_onnx_hash", return_value=BMRLNAP_ONNX), \
          mock.patch("openpilot.sunnypilot.models.default_chestnut.fetch_hf_defaults", return_value=HF_DEFAULTS), \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes CI failures from run https://github.com/mvl-boston/openpilot/actions/runs/34558588762 after merging #174.

## Changes

### `default_chestnut.py`
- Replace `artifact.chunks.append()` with capnp-style `artifact.init('chunks', n)` + indexed assignment in both `artifact_from_hf_bundle()` and `artifact_from_manifest_bundle()`.

### `test_default_chestnut.py`
- Initialize capnp `ModelBundle.models` and `artifact.chunks` lists before access in manifest resolution tests.
- Mock `get_selected_bundle` (not bare `params.get`) in `test_needs_default_chestnut_download`.

### `test_lane_centering.py`
- Convert from pytest to unittest so test collection succeeds without a pytest dependency (the only file in the repo importing pytest).

## Expected CI impact
- `test_default_chestnut` should pass
- `test_lane_centering` collection error resolved
- Deliberate fork failures (calibrationd, locationd, process replay, Discourse) unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d4f3b77-adbb-40ef-91d9-fa5437b19f27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d4f3b77-adbb-40ef-91d9-fa5437b19f27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

